### PR TITLE
gitignore: Ignore env folder for virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.yml
 !example-*.yml
 
+env/
 build/
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
This is a really minor change, just ignores the `env` folder commonly used for Python virtual environments. Simplifies development.