### PR TITLE
[discuss] launcher: disable pid check by default

### DIFF
--- a/pylink
+++ b/pylink
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Starts an instance of PyLink IRC Services.')
     parser.add_argument('config', help='specifies the path to the config file (defaults to pylink.yml)', nargs='?', default='pylink.yml')
     parser.add_argument("-v", "--version", help="displays the program version and exits", action='store_true')
-    parser.add_argument("-c", "--no-check-pid", help="disables PID file checking", action='store_true')
+    parser.add_argument("-c", "--check-pid", help="enables PID file checking", action='store_true')
     parser.add_argument("-n", "--no-pid", help="skips generating PID files", action='store_true')
     args = parser.parse_args()
 
@@ -44,9 +44,9 @@ if __name__ == '__main__':
     elif os.name == 'posix':
         sys.stdout.write("\x1b]2;PyLink %s\x07" % __version__)
 
-    # Check for a pid file, unless told not to,
-    # this stops instance overlap, which wrecks clientbots
-    if not args.no_check_pid:
+    # Check for a pid file. This stops instance overlap and user mistakes, which are especially an
+    # issue for clientbot...
+    if args.check_pid:
         config = conf.confname
         if os.path.exists("%s.pid" % config):
             log.error("PID file exists; aborting! If PyLink didn't shut down cleanly last time it "


### PR DESCRIPTION
Postpone making this a default until PyLink 2.0, so migration from 1.0.x to 1.1 is less of a nuisance.

Closes #364.