### PR TITLE
setup.py: remove unneeded . in package_dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         '': ['example-conf.yml', 'example-permissions.yml', 'VERSION', 'README.md'],
     },
 
-    package_dir = {'pylinkirc': '.'},
+    package_dir = {'pylinkirc': ''},
 
     # Executable scripts
     scripts=["pylink", "pylink-mkpasswd"],


### PR DESCRIPTION
'' is synonymous with '.' as '' aka an 'empty string' makes setup.py use the current/root directory of the package