### PR TITLE
[WIP] IRC stack and protocol revamp

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -52,7 +52,7 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         self.sid = None
         self.serverdata = conf.conf['servers'][netname]
         self.botdata = conf.conf['bot']
-        self.protoname = None  # This is updated in init_vars()
+        self.protoname = self.__class__.__module__.split('.')[-1]  # Remove leading pylinkirc.protocols.
         self.proto = self.irc = self  # Backwards compat
 
         # Protocol stuff
@@ -110,8 +110,6 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         (Re)sets an IRC object to its default state. This should be called when
         an IRC object is first created, and on every reconnection to a network.
         """
-        self.protoname = __name__.split('.')[-1]  # Remove leading pylinkirc.protocols.
-
         self.encoding = self.serverdata.get('encoding') or 'utf-8'
 
         # Tracks the main PyLink client's UID.

--- a/classes.py
+++ b/classes.py
@@ -170,10 +170,8 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         # Set up channel logging for the network
         self.log_setup()
 
-    '''
     def __repr__(self):
-        return "<classes.Irc object for %r>" % self.name
-    '''
+        return "<%s object for network %r>" % (self.__class__.name, self.name)
 
     ### General utility functions
     def call_hooks(self, hook_args):
@@ -407,11 +405,10 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
     def _remove_client(self, numeric):
         """Internal function to remove a client from our internal state."""
         for c, v in self.channels.copy().items():
-            v.removeuser(numeric)
+            v.remove_user(numeric)
             # Clear empty non-permanent channels.
             if not (self.channels[c].users or ((self.cmodes.get('permanent'), None) in self.channels[c].modes)):
                 del self.channels[c]
-            assert numeric not in v.users, "IrcChannel's removeuser() is broken!"
 
         sid = self.get_server(numeric)
         log.debug('Removing client %s from self.users', numeric)
@@ -464,7 +461,7 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         if not userobj:
             return False
 
-        # Look for the "service" attribute in the IrcUser object, if one exists.
+        # Look for the "service" attribute in the User object, if one exists.
         try:
             sname = userobj.service
             # Warn if the service name we fetched isn't a registered service.
@@ -627,9 +624,9 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
                         log.debug('(%s) Final prefixmodes list: %s', self.name, pmodelist)
 
                 if real_mode[0] in self.prefixmodes:
-                    # Don't add prefix modes to IrcChannel.modes; they belong in the
+                    # Don't add prefix modes to Channel.modes; they belong in the
                     # prefixmodes mapping handled above.
-                    log.debug('(%s) Not adding mode %s to IrcChannel.modes because '
+                    log.debug('(%s) Not adding mode %s to Channel.modes because '
                               'it\'s a prefix mode.', self.name, str(mode))
                     continue
 
@@ -934,7 +931,7 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
         Checks whether the given user has operator status on PyLink, raising
         NotAuthorizedError and logging the access denial if not.
         """
-        log.warning("(%s) Irc.check_authenticated() is deprecated as of PyLink 1.2 and may be "
+        log.warning("(%s) check_authenticated() is deprecated as of PyLink 1.2 and may be "
                     "removed in a future relase. Consider migrating to the PyLink Permissions API.",
                     self.name)
         lastfunc = inspect.stack()[1][3]
@@ -1265,9 +1262,9 @@ class IRCNetwork(PyLinkNetworkCoreWithUtils):
                     log.info('(%s) Enumerating our own SID %s', self.name, self.sid)
                     host = self.hostname()
 
-                    self.servers[self.sid] = IrcServer(None, host, internal=True,
-                            desc=self.serverdata.get('serverdesc')
-                            or conf.conf['bot']['serverdesc'])
+                    self.servers[self.sid] = Server(None, host, internal=True,
+                                                    desc=self.serverdata.get('serverdesc')
+                                                    or conf.conf['bot']['serverdesc'])
 
                     log.info('(%s) Starting ping schedulers....', self.name)
                     self._schedule_ping()
@@ -1437,7 +1434,7 @@ class User():
         self.manipulatable = manipulatable
 
     def __repr__(self):
-        return 'IrcUser(%s/%s)' % (self.uid, self.nick)
+        return 'User(%s/%s)' % (self.uid, self.nick)
 IrcUser = User
 
 class Server():
@@ -1457,7 +1454,7 @@ class Server():
         self.desc = desc
 
     def __repr__(self):
-        return 'IrcServer(%s)' % self.name
+        return 'Server(%s)' % self.name
 IrcServer = Server
 
 class Channel(utils.DeprecatedAttributesObject, utils.CamelCaseToSnakeCase):
@@ -1482,7 +1479,7 @@ class Channel(utils.DeprecatedAttributesObject, utils.CamelCaseToSnakeCase):
         self.deprecated_attributes = {'removeuser': 'Deprecated in 2.0; use remove_user() instead!'}
 
     def __repr__(self):
-        return 'IrcChannel(%s)' % self.name
+        return 'Channel(%s)' % self.name
 
     def remove_user(self, target):
         """Removes a user from a channel."""
@@ -1564,5 +1561,5 @@ class Channel(utils.DeprecatedAttributesObject, utils.CamelCaseToSnakeCase):
             if uid in modelist:
                 result.append(mode)
 
-        return sorted(result, key=self.sortPrefixes)
+        return sorted(result, key=self.sort_prefixes)
 IrcChannel = Channel

--- a/classes.py
+++ b/classes.py
@@ -940,7 +940,7 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
             result = not result
         return result
 
-class PyLinkIRCNetwork(PyLinkNetworkCoreWithUtils):
+class IRCNetwork(PyLinkNetworkCoreWithUtils):
     def __init__(self, *args):
         super().__init__(*args)
         if world.testing:
@@ -1258,7 +1258,7 @@ class PyLinkIRCNetwork(PyLinkNetworkCoreWithUtils):
             else:
                 break
 
-Irc = PyLinkIRCNetwork
+Irc = IRCNetwork
 
 class User():
     """PyLink IRC user class."""

--- a/classes.py
+++ b/classes.py
@@ -1260,7 +1260,7 @@ class PyLinkIRCNetwork(PyLinkNetworkCoreWithUtils):
 
 Irc = PyLinkIRCNetwork
 
-class IrcUser():
+class User():
     """PyLink IRC user class."""
     def __init__(self, nick, ts, uid, server, ident='null', host='null',
                  realname='PyLink dummy client', realhost='null',
@@ -1299,14 +1299,15 @@ class IrcUser():
 
     def __repr__(self):
         return 'IrcUser(%s/%s)' % (self.uid, self.nick)
+IrcUser = User
 
-class IrcServer():
+class Server():
     """PyLink IRC server class.
 
-    uplink: The SID of this IrcServer instance's uplink. This is set to None
-            for the main PyLink PseudoServer!
+    uplink: The SID of this PyLinkServer instance's uplink. This is set to None
+            for the main PyLink server.
     name: The name of the server.
-    internal: Whether the server is an internal PyLink PseudoServer.
+    internal: Whether the server is an internal PyLink server.
     """
 
     def __init__(self, uplink, name, internal=False, desc="(None given)"):
@@ -1318,8 +1319,9 @@ class IrcServer():
 
     def __repr__(self):
         return 'IrcServer(%s)' % self.name
+IrcServer = Server
 
-class IrcChannel():
+class Channel():
     """PyLink IRC channel class."""
     def __init__(self, name=None):
         # Initialize variables, such as the topic, user list, TS, who's opped, etc.
@@ -1420,6 +1422,7 @@ class IrcChannel():
                 result.append(mode)
 
         return sorted(result, key=self.sortPrefixes)
+IrcChannel = Channel
 
 class Protocol():
     """Base Protocol module class for PyLink."""

--- a/classes.py
+++ b/classes.py
@@ -590,7 +590,6 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
 
         The target can be either a channel or a user; this is handled automatically."""
         usermodes = not utils.isChannel(target)
-        log.debug('(%s) Using usermodes for this query? %s', self.name, usermodes)
 
         try:
             if usermodes:

--- a/classes.py
+++ b/classes.py
@@ -1130,11 +1130,11 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
     _getUid = _get_UID
 
 class IRCNetwork(PyLinkNetworkCoreWithUtils):
-    def schedule_ping(self):
+    def _schedule_ping(self):
         """Schedules periodic pings in a loop."""
         self.ping()
 
-        self.pingTimer = threading.Timer(self.pingfreq, self.schedule_ping)
+        self.pingTimer = threading.Timer(self.pingfreq, self._schedule_ping)
         self.pingTimer.daemon = True
         self.pingTimer.name = 'Ping timer loop for %s' % self.name
         self.pingTimer.start()
@@ -1248,7 +1248,7 @@ class IRCNetwork(PyLinkNetworkCoreWithUtils):
                 if checks_ok:
 
                     self.queue_thread = threading.Thread(name="Queue thread for %s" % self.name,
-                                                         target=self.process_queue, daemon=True)
+                                                         target=self._process_queue, daemon=True)
                     self.queue_thread.start()
 
                     self.sid = self.serverdata.get("sid")
@@ -1264,7 +1264,7 @@ class IRCNetwork(PyLinkNetworkCoreWithUtils):
                             or conf.conf['bot']['serverdesc'])
 
                     log.info('(%s) Starting ping schedulers....', self.name)
-                    self.schedule_ping()
+                    self._schedule_ping()
                     log.info('(%s) Server ready; listening for data.', self.name)
                     self.autoconnect_active_multiplier = 1  # Reset any extra autoconnect delays
                     self._run_irc()
@@ -1374,7 +1374,7 @@ class IRCNetwork(PyLinkNetworkCoreWithUtils):
         else:
             self._send(data)
 
-    def process_queue(self):
+    def _process_queue(self):
         """Loop to process outgoing queue data."""
         while True:
             throttle_time = self.serverdata.get('throttle_time', 0.005)

--- a/classes.py
+++ b/classes.py
@@ -403,7 +403,7 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         """
         return capab.lower() in self.protocol_caps
 
-    def remove_client(self, numeric):
+    def _remove_client(self, numeric):
         """Internal function to remove a client from our internal state."""
         for c, v in self.channels.copy().items():
             v.removeuser(numeric)

--- a/classes.py
+++ b/classes.py
@@ -198,7 +198,7 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         if 'ts' not in parsed_args:
             parsed_args['ts'] = int(time.time())
         hook_cmd = command
-        hook_map = self.proto.hook_map
+        hook_map = self.hook_map
 
         # If the hook name is present in the protocol module's hook_map, then we
         # should set the hook name to the name that points to instead.
@@ -249,10 +249,10 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         source = source or self.pseudoclient.uid
 
         if notice:
-            self.proto.notice(source, target, text)
+            self.notice(source, target, text)
             cmd = 'PYLINK_SELF_NOTICE'
         else:
-            self.proto.message(source, target, text)
+            self.message(source, target, text)
             cmd = 'PYLINK_SELF_PRIVMSG'
 
         if loopback:
@@ -324,7 +324,7 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         """Sends a command to the protocol module."""
         log.debug("(%s) <- %s", self.name, line)
         try:
-            hook_args = self.proto.handle_events(line)
+            hook_args = self.handle_events(line)
         except Exception:
             log.exception('(%s) Caught error in handle_events, disconnecting!', self.name)
             log.error('(%s) The offending line was: <- %s', self.name, line)
@@ -346,7 +346,7 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         self.init_vars()
 
         try:
-            self.proto.validateServerConf()
+            self.validateServerConf()
         except AssertionError as e:
             log.exception("(%s) Configuration error: %s", self.name, e)
             raise
@@ -439,7 +439,7 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
     def to_lower(self, text):
         """Returns a lowercase representation of text based on the IRC object's
         casemapping (rfc1459 or ascii)."""
-        if self.proto.casemapping == 'rfc1459':
+        if self.casemapping == 'rfc1459':
             text = text.replace('{', '[')
             text = text.replace('}', ']')
             text = text.replace('|', '\\')
@@ -969,7 +969,7 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
         range.
         """
         # Get the corresponding casemapping value used by ircmatch.
-        if self.proto.casemapping == 'rfc1459':
+        if self.casemapping == 'rfc1459':
             casemapping = 0
         else:
             casemapping = 1
@@ -1132,7 +1132,7 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
 class IRCNetwork(PyLinkNetworkCoreWithUtils):
     def schedule_ping(self):
         """Schedules periodic pings in a loop."""
-        self.proto.ping()
+        self.ping()
 
         self.pingTimer = threading.Timer(self.pingfreq, self.schedule_ping)
         self.pingTimer.daemon = True

--- a/classes.py
+++ b/classes.py
@@ -1294,6 +1294,9 @@ class IRCNetwork(PyLinkNetworkCoreWithUtils):
             # HACK: Don't thread if we're running tests.
             self._connect()
         else:
+            if self.connection_thread and self.connection_thread.is_alive():
+                raise RuntimeError("Refusing to start multiple connection threads for network %r!" % self.name)
+
             self.connection_thread = threading.Thread(target=self._connect,
                                                       name="Listener for %s" %
                                                       self.name)

--- a/classes.py
+++ b/classes.py
@@ -1460,8 +1460,9 @@ class Server():
         return 'IrcServer(%s)' % self.name
 IrcServer = Server
 
-class Channel():
+class Channel(utils.DeprecatedAttributesObject, utils.CamelCaseToSnakeCase):
     """PyLink IRC channel class."""
+
     def __init__(self, name=None):
         # Initialize variables, such as the topic, user list, TS, who's opped, etc.
         self.users = set()
@@ -1478,52 +1479,55 @@ class Channel():
         # Saves the channel name (may be useful to plugins, etc.)
         self.name = name
 
+        self.deprecated_attributes = {'removeuser': 'Deprecated in 2.0; use remove_user() instead!'}
+
     def __repr__(self):
         return 'IrcChannel(%s)' % self.name
 
-    def removeuser(self, target):
+    def remove_user(self, target):
         """Removes a user from a channel."""
         for s in self.prefixmodes.values():
             s.discard(target)
         self.users.discard(target)
+    removeuser = remove_user
 
     def deepcopy(self):
         """Returns a deep copy of the channel object."""
         return deepcopy(self)
 
-    def isVoice(self, uid):
+    def is_voice(self, uid):
         """Returns whether the given user is voice in the channel."""
         return uid in self.prefixmodes['voice']
 
-    def isHalfop(self, uid):
+    def is_halfop(self, uid):
         """Returns whether the given user is halfop in the channel."""
         return uid in self.prefixmodes['halfop']
 
-    def isOp(self, uid):
+    def is_op(self, uid):
         """Returns whether the given user is op in the channel."""
         return uid in self.prefixmodes['op']
 
-    def isAdmin(self, uid):
+    def is_admin(self, uid):
         """Returns whether the given user is admin (&) in the channel."""
         return uid in self.prefixmodes['admin']
 
-    def isOwner(self, uid):
+    def is_owner(self, uid):
         """Returns whether the given user is owner (~) in the channel."""
         return uid in self.prefixmodes['owner']
 
-    def isVoicePlus(self, uid):
+    def is_voice_plus(self, uid):
         """Returns whether the given user is voice or above in the channel."""
         # If the user has any prefix mode, it has to be voice or greater.
         return bool(self.getPrefixModes(uid))
 
-    def isHalfopPlus(self, uid):
+    def is_halfop_plus(self, uid):
         """Returns whether the given user is halfop or above in the channel."""
         for mode in ('halfop', 'op', 'admin', 'owner'):
             if uid in self.prefixmodes[mode]:
                 return True
         return False
 
-    def isOpPlus(self, uid):
+    def is_op_plus(self, uid):
         """Returns whether the given user is op or above in the channel."""
         for mode in ('op', 'admin', 'owner'):
             if uid in self.prefixmodes[mode]:
@@ -1531,7 +1535,7 @@ class Channel():
         return False
 
     @staticmethod
-    def sortPrefixes(key):
+    def sort_prefixes(key):
         """
         Implements a sorted()-compatible sorter for prefix modes, giving each one a
         numeric value.
@@ -1542,7 +1546,7 @@ class Channel():
         # support them.
         return values.get(key, 1000)
 
-    def getPrefixModes(self, uid, prefixmodes=None):
+    def get_prefix_modes(self, uid, prefixmodes=None):
         """Returns a list of all named prefix modes the given user has in the channel.
 
         Optionally, a prefixmodes argument can be given to look at an earlier state of

--- a/classes.py
+++ b/classes.py
@@ -1267,13 +1267,13 @@ class IRCNetwork(PyLinkNetworkCoreWithUtils):
                     self.schedule_ping()
                     log.info('(%s) Server ready; listening for data.', self.name)
                     self.autoconnect_active_multiplier = 1  # Reset any extra autoconnect delays
-                    self.run()
+                    self._run_irc()
                 else:  # Configuration error :(
                     log.error('(%s) A configuration error was encountered '
                               'trying to set up this connection. Please check'
                               ' your configuration file and try again.',
                               self.name)
-            # self.run() or the protocol module it called raised an exception, meaning we've disconnected!
+            # _run_irc() or the protocol module it called raised an exception, meaning we've disconnected!
             # Note: socket.error, ConnectionError, IOError, etc. are included in OSError since Python 3.3,
             # so we don't need to explicitly catch them here.
             # We also catch SystemExit here as a way to abort out connection threads properly, and stop the
@@ -1319,7 +1319,7 @@ class IRCNetwork(PyLinkNetworkCoreWithUtils):
             self.pingTimer.cancel()
         self._post_disconnect()
 
-    def run(self):
+    def _run_irc(self):
         """Main IRC loop which listens for messages."""
         buf = b""
         data = b""

--- a/classes.py
+++ b/classes.py
@@ -27,6 +27,7 @@ from .log import *
 
 ### Exceptions
 
+# XXX: is this the right place to put this class?
 class ProtocolError(RuntimeError):
     pass
 

--- a/classes.py
+++ b/classes.py
@@ -74,13 +74,9 @@ class PyLinkNetworkCore(utils.DeprecatedAttributesObject, utils.CamelCaseToSnake
         self.pingfreq = self.serverdata.get('pingfreq') or 90
         self.pingtimeout = self.pingfreq * 2
 
-        self.queue = None
-
         self.connected = threading.Event()
         self.aborted = threading.Event()
         self.reply_lock = threading.RLock()
-
-        self.pingTimer = None
 
         # Sets the multiplier for autoconnect delay (grows with time).
         self.autoconnect_active_multiplier = 1
@@ -1130,6 +1126,13 @@ class PyLinkNetworkCoreWithUtils(PyLinkNetworkCore):
     _getUid = _get_UID
 
 class IRCNetwork(PyLinkNetworkCoreWithUtils):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.connection_thread = None
+        self.queue = None
+        self.pingTimer = None
+
     def _schedule_ping(self):
         """Schedules periodic pings in a loop."""
         self.ping()

--- a/coremods/control.py
+++ b/coremods/control.py
@@ -130,7 +130,11 @@ def _rehash():
         # Connect any new networks or disconnected networks if they aren't already.
         if (network not in world.networkobjects) or (not world.networkobjects[network].connection_thread.is_alive()):
             proto = utils.getProtocolModule(sdata['protocol'])
-            world.networkobjects[network] = classes.Irc(network, proto, new_conf)
+
+            # API note: 2.0.x style of starting network connections
+            world.networkobjects[network] = newirc = proto.Class(network)
+            newirc.connect()
+
     log.info('Finished reloading PyLink configuration.')
 
 if os.name == 'posix':

--- a/coremods/corecommands.py
+++ b/coremods/corecommands.py
@@ -18,12 +18,12 @@ def _login(irc, source, username):
     irc.users[source].account = username
     irc.reply('Successfully logged in as %s.' % username)
     log.info("(%s) Successful login to %r by %s",
-             irc.name, username, irc.getHostmask(source))
+             irc.name, username, irc.get_hostmask(source))
 
 def _loginfail(irc, source, username):
     """Internal function to process login failures."""
     irc.error('Incorrect credentials.')
-    log.warning("(%s) Failed login to %r from %s", irc.name, username, irc.getHostmask(source))
+    log.warning("(%s) Failed login to %r from %s", irc.name, username, irc.get_hostmask(source))
 
 @utils.add_cmd
 def identify(irc, source, args):
@@ -86,7 +86,7 @@ def load(irc, source, args):
     if name in world.plugins:
         irc.reply("Error: %r is already loaded." % name)
         return
-    log.info('(%s) Loading plugin %r for %s', irc.name, name, irc.getHostmask(source))
+    log.info('(%s) Loading plugin %r for %s', irc.name, name, irc.get_hostmask(source))
     try:
         world.plugins[name] = pl = utils.loadPlugin(name)
     except ImportError as e:
@@ -119,7 +119,7 @@ def unload(irc, source, args):
     modulename = utils.PLUGIN_PREFIX + name
 
     if name in world.plugins:
-        log.info('(%s) Unloading plugin %r for %s', irc.name, name, irc.getHostmask(source))
+        log.info('(%s) Unloading plugin %r for %s', irc.name, name, irc.get_hostmask(source))
         pl = world.plugins[name]
         log.debug('sys.getrefcount of plugin %s is %s', pl, sys.getrefcount(pl))
 

--- a/coremods/exttargets.py
+++ b/coremods/exttargets.py
@@ -41,10 +41,10 @@ def account(irc, host, uid):
                           homenet, realuid)
             return False
 
-    slogin = irc.toLower(userobj.services_account)
+    slogin = irc.to_lower(userobj.services_account)
 
     # Split the given exttarget host into parts, so we know how many to look for.
-    groups = list(map(irc.toLower, host.split(':')))
+    groups = list(map(irc.to_lower, host.split(':')))
     log.debug('(%s) exttargets.account: groups to match: %s', irc.name, groups)
 
     if len(groups) == 1:
@@ -74,10 +74,10 @@ def ircop(irc, host, uid):
 
     if len(groups) == 1:
         # 1st scenario.
-        return irc.isOper(uid, allowAuthed=False)
+        return irc.is_oper(uid, allowAuthed=False)
     else:
-        # 2nd scenario. Use matchHost (ircmatch) to match the opertype glob to the opertype.
-        return irc.matchHost(groups[1], irc.users[uid].opertype)
+        # 2nd scenario. Use match_host (ircmatch) to match the opertype glob to the opertype.
+        return irc.match_host(groups[1], irc.users[uid].opertype)
 
 @bind
 def server(irc, host, uid):
@@ -93,10 +93,10 @@ def server(irc, host, uid):
     log.debug('(%s) exttargets.server: groups to match: %s', irc.name, groups)
 
     if len(groups) >= 2:
-        sid = irc.getServer(uid)
+        sid = irc.get_server(uid)
         query = groups[1]
         # Return True if the SID matches the query or the server's name glob matches it.
-        return sid == query or irc.matchHost(query, irc.getFriendlyName(sid))
+        return sid == query or irc.match_host(query, irc.get_friendly_name(sid))
     # $server alone is invalid. Don't match anything.
     return False
 
@@ -134,8 +134,8 @@ def pylinkacc(irc, host, uid):
     $pylinkacc -> Returns True if the target is logged in to PyLink.
     $pylinkacc:accountname -> Returns True if the target's PyLink login matches the one given.
     """
-    login = irc.toLower(irc.users[uid].account)
-    groups = list(map(irc.toLower, host.split(':')))
+    login = irc.to_lower(irc.users[uid].account)
+    groups = list(map(irc.to_lower, host.split(':')))
     log.debug('(%s) exttargets.pylinkacc: groups to match: %s', irc.name, groups)
 
     if len(groups) == 1:
@@ -187,6 +187,6 @@ def exttarget_and(irc, host, uid):
     targets = targets[1:-1]
     targets = list(filter(None, targets.split('+')))
     log.debug('exttargets_and: using raw subtargets list %r (original query=%r)', targets, host)
-    # Wrap every subtarget into irc.matchHost and return True if all subtargets return True.
-    return all(map(lambda sub_exttarget: irc.matchHost(sub_exttarget, uid), targets))
+    # Wrap every subtarget into irc.match_host and return True if all subtargets return True.
+    return all(map(lambda sub_exttarget: irc.match_host(sub_exttarget, uid), targets))
 world.exttarget_handlers['and'] = exttarget_and

--- a/coremods/exttargets.py
+++ b/coremods/exttargets.py
@@ -123,7 +123,7 @@ def channel(irc, host, uid):
         return uid in irc.channels[channel].users
     elif len(groups) >= 3:
         # For things like #channel:op, check if the query is in the user's prefix modes.
-        return (uid in irc.channels[channel].users) and (groups[2].lower() in irc.channels[channel].getPrefixModes(uid))
+        return (uid in irc.channels[channel].users) and (groups[2].lower() in irc.channels[channel].get_prefix_modes(uid))
 
 @bind
 def pylinkacc(irc, host, uid):

--- a/coremods/handlers.py
+++ b/coremods/handlers.py
@@ -48,7 +48,7 @@ def handle_whois(irc, source, command, args):
                         continue
 
                 # Show the highest prefix mode like a regular IRCd does, if there are any.
-                prefixes = c.getPrefixModes(target)
+                prefixes = c.get_prefix_modes(target)
                 if prefixes:
                     highest = prefixes[-1]
 

--- a/coremods/handlers.py
+++ b/coremods/handlers.py
@@ -11,7 +11,7 @@ def handle_whois(irc, source, command, args):
     target = args['target']
     user = irc.users.get(target)
 
-    f = lambda num, source, text: irc.proto.numeric(irc.sid, num, source, text)
+    f = lambda num, source, text: irc.numeric(irc.sid, num, source, text)
 
     # Get the server that the target is on.
     server = irc.getServer(target)
@@ -118,7 +118,7 @@ def handle_mode(irc, source, command, args):
     # client, revert any forced deoper attempts.
     if irc.isInternalClient(target) and not irc.isInternalClient(source):
         if ('-o', None) in modes and (target == irc.pseudoclient.uid or not irc.isManipulatableClient(target)):
-            irc.proto.mode(irc.sid, target, {('+o', None)})
+            irc.mode(irc.sid, target, {('+o', None)})
 utils.add_hook(handle_mode, 'MODE')
 
 def handle_operup(irc, source, command, args):
@@ -143,11 +143,11 @@ def handle_version(irc, source, command, args):
     """Handles requests for the PyLink server version."""
     # 351 syntax is usually "<server version>. <server hostname> :<anything else you want to add>
     fullversion = irc.version()
-    irc.proto.numeric(irc.sid, 351, source, fullversion)
+    irc.numeric(irc.sid, 351, source, fullversion)
 utils.add_hook(handle_version, 'VERSION')
 
 def handle_time(irc, source, command, args):
     """Handles requests for the PyLink server time."""
     timestring = time.ctime()
-    irc.proto.numeric(irc.sid, 391, source, '%s :%s' % (irc.hostname(), timestring))
+    irc.numeric(irc.sid, 391, source, '%s :%s' % (irc.hostname(), timestring))
 utils.add_hook(handle_time, 'TIME')

--- a/coremods/permissions.py
+++ b/coremods/permissions.py
@@ -60,22 +60,22 @@ def checkPermissions(irc, uid, perms, also_show=[]):
     """
     # For old (< 1.1 login blocks):
     # If the user is logged in, they automatically have all permissions.
-    if irc.matchHost('$pylinkacc', uid) and conf.conf['login'].get('user'):
+    if irc.match_host('$pylinkacc', uid) and conf.conf['login'].get('user'):
         log.debug('permissions: overriding permissions check for old-style admin user %s',
-                  irc.getHostmask(uid))
+                  irc.get_hostmask(uid))
         return True
 
     # Iterate over all hostmask->permission list mappings.
     for host, permlist in permissions.copy().items():
         log.debug('permissions: permlist for %s: %s', host, permlist)
-        if irc.matchHost(host, uid):
+        if irc.match_host(host, uid):
             # Now, iterate over all the perms we are looking for.
             for perm in permlist:
-                # Use irc.matchHost to expand globs in an IRC-case insensitive and wildcard
+                # Use irc.match_host to expand globs in an IRC-case insensitive and wildcard
                 # friendly way. e.g. 'xyz.*.#Channel\' will match 'xyz.manage.#channel|' on IRCds
                 # using the RFC1459 casemapping.
                 log.debug('permissions: checking if %s glob matches anything in %s', perm, permlist)
-                if any(irc.matchHost(perm, p) for p in perms):
+                if any(irc.match_host(perm, p) for p in perms):
                     return True
     raise utils.NotAuthorizedError("You are missing one of the following permissions: %s" %
                                    (', '.join(perms+also_show)))

--- a/coremods/service_support.py
+++ b/coremods/service_support.py
@@ -55,7 +55,7 @@ def spawn_service(irc, source, command, args):
         userobj = irc.users[u]
     else:
         log.debug('(%s) spawn_service: Spawning new client %s', irc.name, nick)
-        userobj = irc.spawnClient(nick, ident, host, modes=modes, opertype="PyLink Service",
+        userobj = irc.spawn_client(nick, ident, host, modes=modes, opertype="PyLink Service",
                                         manipulatable=sbot.manipulatable)
 
     # Store the service name in the IrcUser object for easier access.

--- a/coremods/service_support.py
+++ b/coremods/service_support.py
@@ -58,7 +58,7 @@ def spawn_service(irc, source, command, args):
         userobj = irc.spawn_client(nick, ident, host, modes=modes, opertype="PyLink Service",
                                         manipulatable=sbot.manipulatable)
 
-    # Store the service name in the IrcUser object for easier access.
+    # Store the service name in the User object for easier access.
     userobj.service = name
 
     sbot.uids[irc.name] = u = userobj.uid

--- a/coremods/service_support.py
+++ b/coremods/service_support.py
@@ -14,7 +14,7 @@ def spawn_service(irc, source, command, args):
     # Service name
     name = args['name']
 
-    if name != 'pylink' and not irc.hasCap('can-spawn-clients'):
+    if name != 'pylink' and not irc.has_cap('can-spawn-clients'):
         log.debug("(%s) Not spawning service %s because the server doesn't support spawning clients",
                   irc.name, name)
         return
@@ -49,8 +49,8 @@ def spawn_service(irc, source, command, args):
 
     # Track the service's UIDs on each network.
     log.debug('(%s) spawn_service: Using nick %s for service %s', irc.name, nick, name)
-    u = irc.nickToUid(nick)
-    if u and irc.isInternalClient(u):  # If an internal client exists, reuse it.
+    u = irc.nick_to_uid(nick)
+    if u and irc.is_internal_client(u):  # If an internal client exists, reuse it.
         log.debug('(%s) spawn_service: Using existing client %s/%s', irc.name, u, nick)
         userobj = irc.users[u]
     else:
@@ -101,7 +101,7 @@ def handle_kill(irc, source, command, args):
     """Handle KILLs to PyLink service bots, respawning them as needed."""
     target = args['target']
     userdata = args.get('userdata')
-    sbot = irc.getServiceBot(target)
+    sbot = irc.get_service_bot(target)
     servicename = None
 
     if userdata and hasattr(userdata, 'service'):  # Look for the target's service name attribute
@@ -118,7 +118,7 @@ def handle_kick(irc, source, command, args):
     """Handle KICKs to the PyLink service bots, rejoining channels as needed."""
     kicked = args['target']
     channel = args['channel']
-    sbot = irc.getServiceBot(kicked)
+    sbot = irc.get_service_bot(kicked)
     if sbot:
         sbot.join(irc, channel)
 utils.add_hook(handle_kick, 'KICK')
@@ -128,7 +128,7 @@ def handle_commands(irc, source, command, args):
     target = args['target']
     text = args['text']
 
-    sbot = irc.getServiceBot(target)
+    sbot = irc.get_service_bot(target)
     if sbot:
         sbot.call_cmd(irc, source, text)
 

--- a/coremods/service_support.py
+++ b/coremods/service_support.py
@@ -14,7 +14,7 @@ def spawn_service(irc, source, command, args):
     # Service name
     name = args['name']
 
-    if name != 'pylink' and not irc.proto.hasCap('can-spawn-clients'):
+    if name != 'pylink' and not irc.hasCap('can-spawn-clients'):
         log.debug("(%s) Not spawning service %s because the server doesn't support spawning clients",
                   irc.name, name)
         return
@@ -55,7 +55,7 @@ def spawn_service(irc, source, command, args):
         userobj = irc.users[u]
     else:
         log.debug('(%s) spawn_service: Spawning new client %s', irc.name, nick)
-        userobj = irc.proto.spawnClient(nick, ident, host, modes=modes, opertype="PyLink Service",
+        userobj = irc.spawnClient(nick, ident, host, modes=modes, opertype="PyLink Service",
                                         manipulatable=sbot.manipulatable)
 
     # Store the service name in the IrcUser object for easier access.

--- a/docs/technical/hooks-reference.md
+++ b/docs/technical/hooks-reference.md
@@ -163,7 +163,7 @@ Some hooks do not map directly to IRC commands, but to events that protocol modu
 
 - **PYLINK_CUSTOM_WHOIS**: `{'target': UID1, 'server': SID1}`
     - This hook is called by `coremods/handlers.py` during its WHOIS handling process, to allow plugins to provide custom WHOIS information. The `target` field represents the target UID, while the `server` field represents the SID that should be replying to the WHOIS request. The source of the payload is the user using `/whois`.
-    - Plugins wishing to implement this should use the standard WHOIS numerics, using `irc.proto.numeric()` to reply to the source from the given server.
+    - Plugins wishing to implement this should use the standard WHOIS numerics, using `irc.numeric()` to reply to the source from the given server.
     - This hook replaces the pre-0.8.x fashion of defining custom WHOIS handlers, which was non-standard and poorly documented.
 
 ## Commands handled WITHOUT hooks

--- a/docs/technical/pmodule-spec.md
+++ b/docs/technical/pmodule-spec.md
@@ -77,7 +77,7 @@ internals](https://github.com/GLolol/PyLink/blob/1.0-beta1/classes.py#L474-L483)
 - **`sjoin`**`(self, server, channel, users, ts=None, modes=set())` - Sends an SJOIN for a group of users to a channel. The sender should always be a Server ID (SID). TS is
 optional, and defaults to the one we've stored in the channel state if not given. `users` is a list of `(prefix mode, UID)` pairs. Example uses:
     - `sjoin('100', '#test', [('', '100AAABBC'), ('qo', 100AAABBB'), ('h', '100AAADDD')])`
-    - `sjoin(self.irc.sid, '#test', [('o', self.irc.pseudoclient.uid)])`
+    - `sjoin(self.sid, '#test', [('o', self.pseudoclient.uid)])`
 
 - **`spawnServer`**`(self, name, sid=None, uplink=None, desc=None)` - Spawns a server off another PyLink server. `desc` (server description) defaults to the one in the config. `uplink` defaults to the main PyLink server, and `sid` (the server ID) is automatically generated if not given. Sanity checks for server name and SID validity ARE done by the protocol module here.
 
@@ -105,7 +105,7 @@ A protocol module should also set the following variables in their protocol clas
 
 A protocol module manipulates the following attributes in the IRC object it is attached to:
 
-- `self.irc.cmodes` / `self.irc.umodes`: These are mappings of named IRC modes (e.g. `inviteonly` or `moderated`) to a string list of mode letters, that should be either set during link negotiation or hardcoded into the protocol module. There are also special keys: `*A`, `*B`, `*C`, and `*D`, which **must** be set properly with a list of mode characters for that type of mode.
+- `self.cmodes` / `self.umodes`: These are mappings of named IRC modes (e.g. `inviteonly` or `moderated`) to a string list of mode letters, that should be either set during link negotiation or hardcoded into the protocol module. There are also special keys: `*A`, `*B`, `*C`, and `*D`, which **must** be set properly with a list of mode characters for that type of mode.
     - Types of modes are defined as follows (from http://www.irc.org/tech_docs/005.html):
         - A = Mode that adds or removes a nick or address to a list. Always has a parameter.
         - B = Mode that changes a setting and always has a parameter.
@@ -114,8 +114,8 @@ A protocol module manipulates the following attributes in the IRC object it is a
     - If not defined, these will default to modes defined by RFC 1459: https://github.com/GLolol/PyLink/blob/1.0-beta1/classes.py#L127-L152
     - An example of mode mapping hardcoding can be found here: https://github.com/GLolol/PyLink/blob/1.0-beta1/protocols/ts6.py#L259-L311
     - You can find a list of supported (named) channel modes [here](channel-modes.csv), and a list of user modes [here](user-modes.csv).
-- `self.irc.prefixmodes`: This defines a mapping of prefix modes (+o, +v, etc.) to their respective mode prefix. This will default to `{'o': '@', 'v': '+'}` (the standard op and voice) if not defined.
-    - Example: `self.irc.prefixmodes = {'o': '@', 'h': '%', 'v': '+'}`
+- `self.prefixmodes`: This defines a mapping of prefix modes (+o, +v, etc.) to their respective mode prefix. This will default to `{'o': '@', 'v': '+'}` (the standard op and voice) if not defined.
+    - Example: `self.prefixmodes = {'o': '@', 'h': '%', 'v': '+'}`
 
 ### Topics
 
@@ -167,7 +167,7 @@ As an example, one protocol module that tweaks this is [`Clientbot`](https://git
 
 ## Changes
 * 2017-03-15 (1.2-dev)
-   - Corrected the location of `self.irc.cmodes/umodes/prefixmodes` attributes
+   - Corrected the location of `self.cmodes/umodes/prefixmodes` attributes
    - Mention `self.conf_keys` as a special variable for completeness
 * 2017-01-29 (1.2-dev)
    - NOTICE can now be sent from servers.

--- a/docs/technical/writing-plugins.md
+++ b/docs/technical/writing-plugins.md
@@ -46,7 +46,7 @@ Command handlers do not return anything and can raise exceptions, which are caug
 
 Plugins receive data from the underlying protocol module, and communicate back using outgoing [command functions](pmodule-spec.md) implemented by the protocol module. They should *never* send raw data directly back to IRC, because that wouldn't be portable across different IRCds.
 
-These functions are usually called in this fashion: `irc.proto.command(arg1, arg2, ...)`. For example, the command `irc.proto.join('10XAAAAAB', '#bots')` would join a PyLink client with UID `10XAAAAAB` to channel `#bots`.
+These functions are usually called in this fashion: `irc.command(arg1, arg2, ...)`. For example, the command `irc.join('10XAAAAAB', '#bots')` would join a PyLink client with UID `10XAAAAAB` to channel `#bots`.
 
 For sending messages (e.g. replies to commands), simpler forms of:
 

--- a/plugins/automode.py
+++ b/plugins/automode.py
@@ -113,7 +113,7 @@ def match(irc, channel, uids=None):
     log.debug("(%s) automode: sending modes from modebot_uid %s",
               irc.name, modebot_uid)
 
-    irc.proto.mode(modebot_uid, channel, outgoing_modes)
+    irc.mode(modebot_uid, channel, outgoing_modes)
 
     # Create a hook payload to support plugins like relay.
     irc.callHooks([modebot_uid, 'AUTOMODE_MODE',

--- a/plugins/automode.py
+++ b/plugins/automode.py
@@ -58,7 +58,7 @@ def checkAccess(irc, uid, channel, command):
     # - automode.<command>.#channel: ability to <command> automode on the given channel.
     # - automode.savedb: ability to save the automode DB.
     log.debug('(%s) Automode: checking access for %s/%s for %s capability on %s', irc.name, uid,
-              irc.getHostmask(uid), command, channel)
+              irc.get_hostmask(uid), command, channel)
 
     baseperm = 'automode.%s' % command
     try:
@@ -99,7 +99,7 @@ def match(irc, channel, uids=None):
 
     for mask, modes in dbentry.items():
         for uid in uids:
-            if irc.matchHost(mask, uid):
+            if irc.match_host(mask, uid):
                 # User matched a mask. Filter the mode list given to only those that are valid
                 # prefix mode characters.
                 outgoing_modes += [('+'+mode, uid) for mode in modes if mode in irc.prefixmodes]
@@ -116,7 +116,7 @@ def match(irc, channel, uids=None):
     irc.mode(modebot_uid, channel, outgoing_modes)
 
     # Create a hook payload to support plugins like relay.
-    irc.callHooks([modebot_uid, 'AUTOMODE_MODE',
+    irc.call_hooks([modebot_uid, 'AUTOMODE_MODE',
                   {'target': channel, 'modes': outgoing_modes, 'parse_as': 'MODE'}])
 
 def handle_join(irc, source, command, args):
@@ -124,7 +124,7 @@ def handle_join(irc, source, command, args):
     Automode JOIN listener. This sets modes accordingly if the person joining matches a mask in the
     ACL.
     """
-    channel = irc.toLower(args['channel'])
+    channel = irc.to_lower(args['channel'])
     match(irc, channel, args['users'])
 
 utils.add_hook(handle_join, 'JOIN')
@@ -153,7 +153,7 @@ def getChannelPair(irc, source, chanpair, perm=None):
     except ValueError:
         raise ValueError("Invalid channel pair %r" % chanpair)
     channel = '#' + channel
-    channel = irc.toLower(channel)
+    channel = irc.to_lower(channel)
 
     assert utils.isChannel(channel), "Invalid channel name %s." % channel
 
@@ -202,7 +202,7 @@ def setacc(irc, source, args):
 
     modes = modes.lstrip('+')  # remove extraneous leading +'s
     dbentry[mask] = modes
-    log.info('(%s) %s set modes +%s for %s on %s', ircobj.name, irc.getHostmask(source), modes, mask, channel)
+    log.info('(%s) %s set modes +%s for %s on %s', ircobj.name, irc.get_hostmask(source), modes, mask, channel)
     reply(irc, "Done. \x02%s\x02 now has modes \x02+%s\x02 in \x02%s\x02." % (mask, modes, channel))
 
     # Join the Automode bot to the channel if not explicitly told to.
@@ -233,7 +233,7 @@ def delacc(irc, source, args):
 
     if mask in dbentry:
         del dbentry[mask]
-        log.info('(%s) %s removed modes for %s on %s', ircobj.name, irc.getHostmask(source), mask, channel)
+        log.info('(%s) %s removed modes for %s on %s', ircobj.name, irc.get_hostmask(source), mask, channel)
         reply(irc, "Done. Removed the Automode access entry for \x02%s\x02 in \x02%s\x02." % (mask, channel))
     else:
         error(irc, "No Automode access entry for \x02%s\x02 exists in \x02%s\x02." % (mask, channel))
@@ -299,7 +299,7 @@ def syncacc(irc, source, args):
     else:
         ircobj, channel = getChannelPair(irc, source, chanpair, perm='sync')
 
-    log.info('(%s) %s synced modes on %s', ircobj.name, irc.getHostmask(source), channel)
+    log.info('(%s) %s synced modes on %s', ircobj.name, irc.get_hostmask(source), channel)
     match(ircobj, channel)
 
     reply(irc, 'Done.')
@@ -324,7 +324,7 @@ def clearacc(irc, source, args):
 
     if db.get(ircobj.name+channel):
         del db[ircobj.name+channel]
-        log.info('(%s) %s cleared modes on %s', ircobj.name, irc.getHostmask(source), channel)
+        log.info('(%s) %s cleared modes on %s', ircobj.name, irc.get_hostmask(source), channel)
         reply(irc, "Done. Removed all Automode access entries for \x02%s\x02." % channel)
     else:
         error(irc, "No Automode access entries exist for \x02%s\x02." % channel)

--- a/plugins/bots.py
+++ b/plugins/bots.py
@@ -33,21 +33,21 @@ def quit(irc, source, args):
     except IndexError:
         irc.error("Not enough arguments. Needs 1-2: nick, reason (optional).")
         return
-    if irc.pseudoclient.uid == irc.nickToUid(nick):
+    if irc.pseudoclient.uid == irc.nick_to_uid(nick):
         irc.error("Cannot quit the main PyLink client!")
         return
 
-    u = irc.nickToUid(nick)
+    u = irc.nick_to_uid(nick)
 
     quitmsg =  ' '.join(args[1:]) or 'Client Quit'
 
-    if not irc.isManipulatableClient(u):
+    if not irc.is_manipulatable_client(u):
         irc.error("Cannot force quit a protected PyLink services client.")
         return
 
     irc.quit(u, quitmsg)
     irc.reply("Done.")
-    irc.callHooks([u, 'PYLINK_BOTSPLUGIN_QUIT', {'text': quitmsg, 'parse_as': 'QUIT'}])
+    irc.call_hooks([u, 'PYLINK_BOTSPLUGIN_QUIT', {'text': quitmsg, 'parse_as': 'QUIT'}])
 
 def joinclient(irc, source, args):
     """[<target>] <channel1>[,<channel2>,<channel3>,...]
@@ -63,9 +63,9 @@ def joinclient(irc, source, args):
     try:
         # Check if the first argument is an existing PyLink client. If it is not,
         # then assume that the first argument was actually the channels being joined.
-        u = irc.nickToUid(args[0])
+        u = irc.nick_to_uid(args[0])
 
-        if not irc.isInternalClient(u):  # First argument isn't one of our clients
+        if not irc.is_internal_client(u):  # First argument isn't one of our clients
             raise IndexError
 
         clist = args[1]
@@ -82,7 +82,7 @@ def joinclient(irc, source, args):
         irc.error("No valid channels given.")
         return
 
-    if not (irc.isManipulatableClient(u) or irc.getServiceBot(u)):
+    if not (irc.is_manipulatable_client(u) or irc.get_service_bot(u)):
         irc.error("Cannot force join a protected PyLink services client.")
         return
 
@@ -104,7 +104,7 @@ def joinclient(irc, source, args):
             irc.join(u, real_channel)
 
         # Call a join hook manually so other plugins like relay can understand it.
-        irc.callHooks([u, 'PYLINK_BOTSPLUGIN_JOIN', {'channel': real_channel, 'users': [u],
+        irc.call_hooks([u, 'PYLINK_BOTSPLUGIN_JOIN', {'channel': real_channel, 'users': [u],
                                                      'modes': irc.channels[real_channel].modes,
                                                      'parse_as': 'JOIN'}])
     irc.reply("Done.")
@@ -128,7 +128,7 @@ def nick(irc, source, args):
         except IndexError:
             irc.error("Not enough arguments. Needs 1-2: nick (optional), newnick.")
             return
-    u = irc.nickToUid(nick)
+    u = irc.nick_to_uid(nick)
 
     if newnick in ('0', u):  # Allow /nick 0 to work
         newnick = u
@@ -137,14 +137,14 @@ def nick(irc, source, args):
         irc.error('Invalid nickname %r.' % newnick)
         return
 
-    elif not (irc.isManipulatableClient(u) or irc.getServiceBot(u)):
+    elif not (irc.is_manipulatable_client(u) or irc.get_service_bot(u)):
         irc.error("Cannot force nick changes for a protected PyLink services client.")
         return
 
     irc.nick(u, newnick)
     irc.reply("Done.")
     # Ditto above: manually send a NICK change hook payload to other plugins.
-    irc.callHooks([u, 'PYLINK_BOTSPLUGIN_NICK', {'newnick': newnick, 'oldnick': nick, 'parse_as': 'NICK'}])
+    irc.call_hooks([u, 'PYLINK_BOTSPLUGIN_NICK', {'newnick': newnick, 'oldnick': nick, 'parse_as': 'NICK'}])
 
 @utils.add_cmd
 def part(irc, source, args):
@@ -161,8 +161,8 @@ def part(irc, source, args):
 
         # First, check if the first argument is an existing PyLink client. If it is not,
         # then assume that the first argument was actually the channels being parted.
-        u = irc.nickToUid(nick)
-        if not irc.isInternalClient(u):  # First argument isn't one of our clients
+        u = irc.nick_to_uid(nick)
+        if not irc.is_internal_client(u):  # First argument isn't one of our clients
             raise IndexError
 
     except IndexError:  # No nick was given; shift arguments one to the left.
@@ -180,7 +180,7 @@ def part(irc, source, args):
         irc.error("No valid channels given.")
         return
 
-    if not (irc.isManipulatableClient(u) or irc.getServiceBot(u)):
+    if not (irc.is_manipulatable_client(u) or irc.get_service_bot(u)):
         irc.error("Cannot force part a protected PyLink services client.")
         return
 
@@ -191,7 +191,7 @@ def part(irc, source, args):
         irc.part(u, channel, reason)
 
     irc.reply("Done.")
-    irc.callHooks([u, 'PYLINK_BOTSPLUGIN_PART', {'channels': clist, 'text': reason, 'parse_as': 'PART'}])
+    irc.call_hooks([u, 'PYLINK_BOTSPLUGIN_PART', {'channels': clist, 'text': reason, 'parse_as': 'PART'}])
 
 @utils.add_cmd
 def msg(irc, source, args):
@@ -208,8 +208,8 @@ def msg(irc, source, args):
 
         # First, check if the first argument is an existing PyLink client. If it is not,
         # then assume that the first argument was actually the message TARGET.
-        sourceuid = irc.nickToUid(msgsource)
-        if not irc.isInternalClient(sourceuid):  # First argument isn't one of our clients
+        sourceuid = irc.nick_to_uid(msgsource)
+        if not irc.is_internal_client(sourceuid):  # First argument isn't one of our clients
             raise IndexError
 
         if not text:
@@ -229,7 +229,7 @@ def msg(irc, source, args):
 
     if not utils.isChannel(target):
         # Convert nick of the message target to a UID, if the target isn't a channel
-        real_target = irc.nickToUid(target)
+        real_target = irc.nick_to_uid(target)
         if real_target is None:  # Unknown target user, if target isn't a valid channel name
             irc.error('Unknown user %r.' % target)
             return
@@ -238,5 +238,5 @@ def msg(irc, source, args):
 
     irc.message(sourceuid, real_target, text)
     irc.reply("Done.")
-    irc.callHooks([sourceuid, 'PYLINK_BOTSPLUGIN_MSG', {'target': real_target, 'text': text, 'parse_as': 'PRIVMSG'}])
+    irc.call_hooks([sourceuid, 'PYLINK_BOTSPLUGIN_MSG', {'target': real_target, 'text': text, 'parse_as': 'PRIVMSG'}])
 utils.add_cmd(msg, 'say')

--- a/plugins/bots.py
+++ b/plugins/bots.py
@@ -18,7 +18,7 @@ def spawnclient(irc, source, args):
     except ValueError:
         irc.error("Not enough arguments. Needs 3: nick, user, host.")
         return
-    irc.spawnClient(nick, ident, host, manipulatable=True)
+    irc.spawn_client(nick, ident, host, manipulatable=True)
     irc.reply("Done.")
 
 @utils.add_cmd

--- a/plugins/bots.py
+++ b/plugins/bots.py
@@ -18,7 +18,7 @@ def spawnclient(irc, source, args):
     except ValueError:
         irc.error("Not enough arguments. Needs 3: nick, user, host.")
         return
-    irc.proto.spawnClient(nick, ident, host, manipulatable=True)
+    irc.spawnClient(nick, ident, host, manipulatable=True)
     irc.reply("Done.")
 
 @utils.add_cmd
@@ -45,7 +45,7 @@ def quit(irc, source, args):
         irc.error("Cannot force quit a protected PyLink services client.")
         return
 
-    irc.proto.quit(u, quitmsg)
+    irc.quit(u, quitmsg)
     irc.reply("Done.")
     irc.callHooks([u, 'PYLINK_BOTSPLUGIN_QUIT', {'text': quitmsg, 'parse_as': 'QUIT'}])
 
@@ -99,9 +99,9 @@ def joinclient(irc, source, args):
 
         # join() doesn't support prefixes.
         if prefixes:
-            irc.proto.sjoin(irc.sid, real_channel, [(joinmodes, u)])
+            irc.sjoin(irc.sid, real_channel, [(joinmodes, u)])
         else:
-            irc.proto.join(u, real_channel)
+            irc.join(u, real_channel)
 
         # Call a join hook manually so other plugins like relay can understand it.
         irc.callHooks([u, 'PYLINK_BOTSPLUGIN_JOIN', {'channel': real_channel, 'users': [u],
@@ -141,7 +141,7 @@ def nick(irc, source, args):
         irc.error("Cannot force nick changes for a protected PyLink services client.")
         return
 
-    irc.proto.nick(u, newnick)
+    irc.nick(u, newnick)
     irc.reply("Done.")
     # Ditto above: manually send a NICK change hook payload to other plugins.
     irc.callHooks([u, 'PYLINK_BOTSPLUGIN_NICK', {'newnick': newnick, 'oldnick': nick, 'parse_as': 'NICK'}])
@@ -188,7 +188,7 @@ def part(irc, source, args):
         if not utils.isChannel(channel):
             irc.error("Invalid channel name %r." % channel)
             return
-        irc.proto.part(u, channel, reason)
+        irc.part(u, channel, reason)
 
     irc.reply("Done.")
     irc.callHooks([u, 'PYLINK_BOTSPLUGIN_PART', {'channels': clist, 'text': reason, 'parse_as': 'PART'}])
@@ -236,7 +236,7 @@ def msg(irc, source, args):
     else:
         real_target = target
 
-    irc.proto.message(sourceuid, real_target, text)
+    irc.message(sourceuid, real_target, text)
     irc.reply("Done.")
     irc.callHooks([sourceuid, 'PYLINK_BOTSPLUGIN_MSG', {'target': real_target, 'text': text, 'parse_as': 'PRIVMSG'}])
 utils.add_cmd(msg, 'say')

--- a/plugins/changehost.py
+++ b/plugins/changehost.py
@@ -78,7 +78,7 @@ def _changehost(irc, target, args):
                 if char not in allowed_chars:
                     new_host = new_host.replace(char, '-')
 
-            irc.proto.updateClient(target, 'HOST', new_host)
+            irc.updateClient(target, 'HOST', new_host)
 
             # Only operate on the first match.
             break

--- a/plugins/changehost.py
+++ b/plugins/changehost.py
@@ -78,7 +78,7 @@ def _changehost(irc, target, args):
                 if char not in allowed_chars:
                     new_host = new_host.replace(char, '-')
 
-            irc.updateClient(target, 'HOST', new_host)
+            irc.update_client(target, 'HOST', new_host)
 
             # Only operate on the first match.
             break

--- a/plugins/changehost.py
+++ b/plugins/changehost.py
@@ -19,7 +19,7 @@ def _changehost(irc, target, args):
 
     if target not in irc.users:
         return
-    elif irc.isInternalClient(target):
+    elif irc.is_internal_client(target):
         log.debug('(%s) Skipping changehost on internal client %s', irc.name, target)
         return
 
@@ -48,7 +48,7 @@ def _changehost(irc, target, args):
 
     for host_glob, host_template in changehost_hosts.items():
         log.debug('(%s) Changehost: checking mask %s', irc.name, host_glob)
-        if irc.matchHost(host_glob, target, ip=match_ip, realhost=match_realhosts):
+        if irc.match_host(host_glob, target, ip=match_ip, realhost=match_realhosts):
             log.debug('(%s) Changehost matched mask %s', irc.name, host_glob)
             # This uses template strings for simple substitution:
             # https://docs.python.org/3/library/string.html#template-strings
@@ -103,13 +103,13 @@ def handle_chghost(irc, sender, command, args):
 
     target = args['target']
 
-    if (not irc.isInternalClient(sender)) and (not irc.isInternalServer(sender)):
+    if (not irc.is_internal_client(sender)) and (not irc.is_internal_server(sender)):
         if irc.name in changehost_conf.get('enforced_nets', []):
             log.debug('(%s) Enforce for network is on, re-checking host for target %s/%s',
-                      irc.name, target, irc.getFriendlyName(target))
+                      irc.name, target, irc.get_friendly_name(target))
 
             for ex in changehost_conf.get("enforce_exceptions", []):
-                if irc.matchHost(ex, target):
+                if irc.match_host(ex, target):
                     log.debug('(%s) Skipping host change for target %s; they are exempted by mask %s',
                               irc.name, target, ex)
                     return

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -110,7 +110,7 @@ def showchan(irc, source, args):
 
     # Mark TS values as untrusted on Clientbot and others (where TS is read-only or not trackable)
     f('\x02Channel creation time\x02: %s (%s)%s' % (ctime(c.ts), c.ts,
-                                                    ' [UNTRUSTED]' if not irc.proto.hasCap('has-ts') else ''))
+                                                    ' [UNTRUSTED]' if not irc.hasCap('has-ts') else ''))
 
     # Show only modes that aren't list-style modes.
     modes = irc.joinModes([m for m in c.modes if m[0] not in irc.cmodes['*A']], sort=True)

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -120,7 +120,7 @@ def showchan(irc, source, args):
         # Iterate over the user list, sorted by nick.
         for user, nick in sorted(zip(c.users, nicks),
                                  key=lambda userpair: userpair[1].lower()):
-            for pmode in c.getPrefixModes(user):
+            for pmode in c.get_prefix_modes(user):
                 # Show prefix modes in order from highest to lowest.
                 nick = irc.prefixmodes.get(irc.cmodes.get(pmode, ''), '') + nick
             nicklist.append(nick)

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -29,7 +29,7 @@ def status(irc, source, args):
         irc.reply('You are identified as \x02%s\x02.' % identified)
     else:
         irc.reply('You are not identified as anyone.')
-    irc.reply('Operator access: \x02%s\x02' % bool(irc.isOper(source)))
+    irc.reply('Operator access: \x02%s\x02' % bool(irc.is_oper(source)))
 
 _none = '\x1D(none)\x1D'
 @utils.add_cmd
@@ -43,10 +43,10 @@ def showuser(irc, source, args):
     except IndexError:
         irc.error("Not enough arguments. Needs 1: nick.")
         return
-    u = irc.nickToUid(target) or target
+    u = irc.nick_to_uid(target) or target
     # Only show private info if the person is calling 'showuser' on themselves,
     # or is an oper.
-    verbose = irc.isOper(source) or u == source
+    verbose = irc.is_oper(source) or u == source
     if u not in irc.users:
         irc.error('Unknown user %r.' % target)
         return
@@ -57,7 +57,7 @@ def showuser(irc, source, args):
     f('Showing information on user \x02%s\x02 (%s@%s): %s' % (userobj.nick, userobj.ident,
       userobj.host, userobj.realname))
 
-    sid = irc.getServer(u)
+    sid = irc.get_server(u)
     serverobj = irc.servers[sid]
     ts = userobj.ts
 
@@ -67,7 +67,7 @@ def showuser(irc, source, args):
 
     if verbose:  # Oper only data: user modes, channels on, account info, etc.
 
-        f('\x02User modes\x02: %s' % irc.joinModes(userobj.modes, sort=True))
+        f('\x02User modes\x02: %s' % irc.join_modes(userobj.modes, sort=True))
         f('\x02Protocol UID\x02: %s; \x02Real host\x02: %s; \x02IP\x02: %s' % \
           (u, userobj.realhost, userobj.ip))
         channels = sorted(userobj.channels)
@@ -83,7 +83,7 @@ def showchan(irc, source, args):
     Shows information about <channel>."""
     permissions.checkPermissions(irc, source, ['commands.showchan'])
     try:
-        channel = irc.toLower(args[0])
+        channel = irc.to_lower(args[0])
     except IndexError:
         irc.error("Not enough arguments. Needs 1: channel.")
         return
@@ -95,7 +95,7 @@ def showchan(irc, source, args):
 
     c = irc.channels[channel]
     # Only show verbose info if caller is oper or is in the target channel.
-    verbose = source in c.users or irc.isOper(source)
+    verbose = source in c.users or irc.is_oper(source)
     secret = ('s', None) in c.modes
     if secret and not verbose:
         # Hide secret channels from normal users.
@@ -110,10 +110,10 @@ def showchan(irc, source, args):
 
     # Mark TS values as untrusted on Clientbot and others (where TS is read-only or not trackable)
     f('\x02Channel creation time\x02: %s (%s)%s' % (ctime(c.ts), c.ts,
-                                                    ' [UNTRUSTED]' if not irc.hasCap('has-ts') else ''))
+                                                    ' [UNTRUSTED]' if not irc.has_cap('has-ts') else ''))
 
     # Show only modes that aren't list-style modes.
-    modes = irc.joinModes([m for m in c.modes if m[0] not in irc.cmodes['*A']], sort=True)
+    modes = irc.join_modes([m for m in c.modes if m[0] not in irc.cmodes['*A']], sort=True)
     f('\x02Channel modes\x02: %s' % modes)
     if verbose:
         nicklist = []
@@ -179,7 +179,7 @@ def logout(irc, source, args):
             irc.error("You are not logged in!")
             return
     else:
-        otheruid = irc.nickToUid(othernick)
+        otheruid = irc.nick_to_uid(othernick)
         if not otheruid:
             irc.error("Unknown user %s." % othernick)
             return

--- a/plugins/example.py
+++ b/plugins/example.py
@@ -18,7 +18,7 @@ def hook_privmsg(irc, source, command, args):
     channel = args['target']
     text = args['text']
 
-    # irc.pseudoclient stores the IrcUser object of the main PyLink client.
+    # irc.pseudoclient stores the User object of the main PyLink client.
     # (i.e. the user defined in the bot: section of the config)
     if utils.isChannel(channel) and irc.pseudoclient.nick in text:
         irc.msg(channel, 'hi there!')

--- a/plugins/exec.py
+++ b/plugins/exec.py
@@ -34,7 +34,7 @@ def _exec(irc, source, args, locals_dict=None):
         return
 
     log.info('(%s) Executing %r for %s', irc.name, args,
-             irc.getHostmask(source))
+             irc.get_hostmask(source))
     if locals_dict is None:
         locals_dict = locals()
     else:
@@ -86,7 +86,7 @@ def _eval(irc, source, args, locals_dict=None, pretty_print=False):
         locals_dict['args'] = args
 
     log.info('(%s) Evaluating %r for %s', irc.name, args,
-             irc.getHostmask(source))
+             irc.get_hostmask(source))
 
     result = eval(args, globals(), locals_dict)
 
@@ -150,7 +150,7 @@ def raw(irc, source, args):
         return
 
     log.debug('(%s) Sending raw text %r to IRC for %s', irc.name, args,
-              irc.getHostmask(source))
+              irc.get_hostmask(source))
     irc.send(args)
 
     irc.reply("Done.")
@@ -170,5 +170,5 @@ def inject(irc, source, args):
         return
 
     log.info('(%s) Injecting raw text %r into protocol module for %s', irc.name,
-             args, irc.getHostmask(source))
+             args, irc.get_hostmask(source))
     irc.reply(irc.runline(args))

--- a/plugins/fantasy.py
+++ b/plugins/fantasy.py
@@ -12,7 +12,7 @@ def handle_fantasy(irc, source, command, args):
     channel = args['target']
     orig_text = args['text']
 
-    if utils.isChannel(channel) and not irc.isInternalClient(source):
+    if utils.isChannel(channel) and not irc.is_internal_client(source):
         # The following conditions must be met for an incoming message for
         # fantasy to trigger:
         #   1) The message target is a channel.
@@ -42,7 +42,7 @@ def handle_fantasy(irc, source, command, args):
 
                 # If responding to nick is enabled, add variations of the current nick
                 # to the prefix list: "<nick>," and "<nick>:"
-                nick = irc.toLower(irc.users[servuid].nick)
+                nick = irc.to_lower(irc.users[servuid].nick)
 
                 nick_prefixes = [nick+',', nick+':']
                 if respondtonick:
@@ -52,7 +52,7 @@ def handle_fantasy(irc, source, command, args):
                     # No prefixes were set, so skip.
                     continue
 
-                lowered_text = irc.toLower(orig_text)
+                lowered_text = irc.to_lower(orig_text)
                 for prefix in filter(None, prefixes):  # Cycle through the prefixes list we finished with.
                      if lowered_text.startswith(prefix):
 

--- a/plugins/global.py
+++ b/plugins/global.py
@@ -20,12 +20,12 @@ def g(irc, source, args):
     for name, ircd in world.networkobjects.items():
         if ircd.connected.is_set():  # Only attempt to send to connected networks
             for channel in ircd.pseudoclient.channels:
-                subst = {'sender': irc.getFriendlyName(source),
+                subst = {'sender': irc.get_friendly_name(source),
                          'network': irc.name,
-                         'fullnetwork': irc.getFullNetworkName(),
+                         'fullnetwork': irc.get_full_network_name(),
                          'current_channel': channel,
                          'current_network': ircd.name,
-                         'current_fullnetwork': ircd.getFullNetworkName(),
+                         'current_fullnetwork': ircd.get_full_network_name(),
                          'text': message}
 
                 # Disable relaying or other plugins handling the global message.

--- a/plugins/opercmds.py
+++ b/plugins/opercmds.py
@@ -27,10 +27,10 @@ def checkban(irc, source, args):
 
         results = 0
         for uid, userobj in irc.users.copy().items():
-            if irc.matchHost(banmask, uid):
+            if irc.match_host(banmask, uid):
                 if results < 50:  # XXX rather arbitrary limit
                     s = "\x02%s\x02 (%s@%s) [%s] {\x02%s\x02}" % (userobj.nick, userobj.ident,
-                        userobj.host, userobj.realname, irc.getFriendlyName(irc.getServer(uid)))
+                        userobj.host, userobj.realname, irc.get_friendly_name(irc.get_server(uid)))
 
                     # Always reply in private to prevent information leaks.
                     irc.reply(s, private=True)
@@ -42,9 +42,9 @@ def checkban(irc, source, args):
             else:
                 irc.msg(source, "No results found.", notice=True)
     else:
-        # Target can be both a nick (of an online user) or a hostmask. irc.matchHost() handles this
+        # Target can be both a nick (of an online user) or a hostmask. irc.match_host() handles this
         # automatically.
-        if irc.matchHost(banmask, targetmask):
+        if irc.match_host(banmask, targetmask):
             irc.reply('Yes, \x02%s\x02 matches \x02%s\x02.' % (targetmask, banmask))
         else:
             irc.reply('No, \x02%s\x02 does not match \x02%s\x02.' % (targetmask, banmask))
@@ -61,7 +61,7 @@ def jupe(irc, source, args):
     try:
         servername = args[0]
         reason = ' '.join(args[1:]) or "No reason given"
-        desc = "Juped by %s: [%s]" % (irc.getHostmask(source), reason)
+        desc = "Juped by %s: [%s]" % (irc.get_hostmask(source), reason)
     except IndexError:
         irc.error('Not enough arguments. Needs 1-2: servername, reason (optional).')
         return
@@ -72,7 +72,7 @@ def jupe(irc, source, args):
 
     sid = irc.spawnServer(servername, desc=desc)
 
-    irc.callHooks([irc.pseudoclient.uid, 'OPERCMDS_SPAWNSERVER',
+    irc.call_hooks([irc.pseudoclient.uid, 'OPERCMDS_SPAWNSERVER',
                    {'name': servername, 'sid': sid, 'text': desc}])
 
     irc.reply("Done.")
@@ -85,14 +85,14 @@ def kick(irc, source, args):
     Admin only. Kicks <user> from the specified channel."""
     permissions.checkPermissions(irc, source, ['opercmds.kick'])
     try:
-        channel = irc.toLower(args[0])
+        channel = irc.to_lower(args[0])
         target = args[1]
         reason = ' '.join(args[2:])
     except IndexError:
         irc.error("Not enough arguments. Needs 2-3: channel, target, reason (optional).")
         return
 
-    targetu = irc.nickToUid(target)
+    targetu = irc.nick_to_uid(target)
 
     if channel not in irc.channels:  # KICK only works on channels that exist.
         irc.error("Unknown channel %r." % channel)
@@ -106,7 +106,7 @@ def kick(irc, source, args):
     sender = irc.pseudoclient.uid
     irc.kick(sender, channel, targetu, reason)
     irc.reply("Done.")
-    irc.callHooks([sender, 'CHANCMDS_KICK', {'channel': channel, 'target': targetu,
+    irc.call_hooks([sender, 'CHANCMDS_KICK', {'channel': channel, 'target': targetu,
                                         'text': reason, 'parse_as': 'KICK'}])
 
 @utils.add_cmd
@@ -124,7 +124,7 @@ def kill(irc, source, args):
 
     # Convert the source and target nicks to UIDs.
     sender = irc.pseudoclient.uid
-    targetu = irc.nickToUid(target)
+    targetu = irc.nick_to_uid(target)
     userdata = irc.users.get(targetu)
 
     if targetu not in irc.users:
@@ -135,10 +135,10 @@ def kill(irc, source, args):
     irc.kill(sender, targetu, reason)
 
     # Format the kill reason properly in hooks.
-    reason = "Killed (%s (%s))" % (irc.getFriendlyName(sender), reason)
+    reason = "Killed (%s (%s))" % (irc.get_friendly_name(sender), reason)
 
     irc.reply("Done.")
-    irc.callHooks([sender, 'CHANCMDS_KILL', {'target': targetu, 'text': reason,
+    irc.call_hooks([sender, 'CHANCMDS_KILL', {'target': targetu, 'text': reason,
                                         'userdata': userdata, 'parse_as': 'KILL'}])
 
 @utils.add_cmd
@@ -164,7 +164,7 @@ def mode(irc, source, args):
         irc.error("No valid modes were given.")
         return
 
-    parsedmodes = irc.parseModes(target, modes)
+    parsedmodes = irc.parse_modes(target, modes)
 
     if not parsedmodes:
         # Modes were given but they failed to parse into anything meaningful.
@@ -176,7 +176,7 @@ def mode(irc, source, args):
     irc.mode(irc.pseudoclient.uid, target, parsedmodes)
 
     # Call the appropriate hooks for plugins like relay.
-    irc.callHooks([irc.pseudoclient.uid, 'OPERCMDS_MODEOVERRIDE',
+    irc.call_hooks([irc.pseudoclient.uid, 'OPERCMDS_MODEOVERRIDE',
                    {'target': target, 'modes': parsedmodes, 'parse_as': 'MODE'}])
 
     irc.reply("Done.")
@@ -201,6 +201,6 @@ def topic(irc, source, args):
     irc.topic(irc.pseudoclient.uid, channel, topic)
 
     irc.reply("Done.")
-    irc.callHooks([irc.pseudoclient.uid, 'CHANCMDS_TOPIC',
+    irc.call_hooks([irc.pseudoclient.uid, 'CHANCMDS_TOPIC',
                    {'channel': channel, 'text': topic, 'setter': source,
                     'parse_as': 'TOPIC'}])

--- a/plugins/opercmds.py
+++ b/plugins/opercmds.py
@@ -70,7 +70,7 @@ def jupe(irc, source, args):
         irc.error("Invalid server name '%s'." % servername)
         return
 
-    sid = irc.spawnServer(servername, desc=desc)
+    sid = irc.spawn_server(servername, desc=desc)
 
     irc.call_hooks([irc.pseudoclient.uid, 'OPERCMDS_SPAWNSERVER',
                    {'name': servername, 'sid': sid, 'text': desc}])

--- a/plugins/opercmds.py
+++ b/plugins/opercmds.py
@@ -70,7 +70,7 @@ def jupe(irc, source, args):
         irc.error("Invalid server name '%s'." % servername)
         return
 
-    sid = irc.proto.spawnServer(servername, desc=desc)
+    sid = irc.spawnServer(servername, desc=desc)
 
     irc.callHooks([irc.pseudoclient.uid, 'OPERCMDS_SPAWNSERVER',
                    {'name': servername, 'sid': sid, 'text': desc}])
@@ -104,7 +104,7 @@ def kick(irc, source, args):
         return
 
     sender = irc.pseudoclient.uid
-    irc.proto.kick(sender, channel, targetu, reason)
+    irc.kick(sender, channel, targetu, reason)
     irc.reply("Done.")
     irc.callHooks([sender, 'CHANCMDS_KICK', {'channel': channel, 'target': targetu,
                                         'text': reason, 'parse_as': 'KICK'}])
@@ -132,7 +132,7 @@ def kill(irc, source, args):
         irc.error("No such nick '%s'." % target)
         return
 
-    irc.proto.kill(sender, targetu, reason)
+    irc.kill(sender, targetu, reason)
 
     # Format the kill reason properly in hooks.
     reason = "Killed (%s (%s))" % (irc.getFriendlyName(sender), reason)
@@ -173,7 +173,7 @@ def mode(irc, source, args):
         irc.error("No valid modes were given.")
         return
 
-    irc.proto.mode(irc.pseudoclient.uid, target, parsedmodes)
+    irc.mode(irc.pseudoclient.uid, target, parsedmodes)
 
     # Call the appropriate hooks for plugins like relay.
     irc.callHooks([irc.pseudoclient.uid, 'OPERCMDS_MODEOVERRIDE',
@@ -198,7 +198,7 @@ def topic(irc, source, args):
         irc.error("Unknown channel %r." % channel)
         return
 
-    irc.proto.topic(irc.pseudoclient.uid, channel, topic)
+    irc.topic(irc.pseudoclient.uid, channel, topic)
 
     irc.reply("Done.")
     irc.callHooks([irc.pseudoclient.uid, 'CHANCMDS_TOPIC',

--- a/plugins/relay.py
+++ b/plugins/relay.py
@@ -206,7 +206,7 @@ def get_prefix_modes(irc, remoteirc, channel, user, mlist=None):
         # Note: reverse the order so prefix modes are bursted in their traditional order
         # (e.g. owner before op before halfop). TODO: SJOIN modes should probably be
         # consistently sorted IRCd-side.
-        for pmode in reversed(irc.channels[channel].getPrefixModes(user, prefixmodes=mlist)):
+        for pmode in reversed(irc.channels[channel].get_prefix_modes(user, prefixmodes=mlist)):
             if pmode in remoteirc.cmodes:
                 modes += remoteirc.cmodes[pmode]
     return modes
@@ -920,11 +920,11 @@ def handle_join(irc, numeric, command, args):
             # XXX: Find the diff of the new and old mode lists of the channel. Not pretty, but I'd
             # rather not change the 'users' format of SJOIN just for this. -GL
             try:
-                oldmodes = set(chandata.getPrefixModes(user))
+                oldmodes = set(chandata.get_prefix_modes(user))
             except KeyError:
                 # User was never in channel. Treat their mode list as empty.
                 oldmodes = set()
-            newmodes = set(current_chandata.getPrefixModes(user))
+            newmodes = set(current_chandata.get_prefix_modes(user))
             modediff = newmodes - oldmodes
             log.debug('(%s) relay.handle_join: mode diff for %s on %s: %s oldmodes=%s newmodes=%s',
                       irc.name, user, channel, modediff, oldmodes, newmodes)

--- a/plugins/relay.py
+++ b/plugins/relay.py
@@ -219,7 +219,7 @@ def spawn_relay_server(irc, remoteirc):
             suffix = conf.conf.get('relay', {}).get('server_suffix', 'relay')
             # Strip any leading or trailing .'s
             suffix = suffix.strip('.')
-            sid = irc.spawnServer('%s.%s' % (remoteirc.name, suffix),
+            sid = irc.spawn_server('%s.%s' % (remoteirc.name, suffix),
                                         desc="PyLink Relay network - %s" %
                                         (remoteirc.get_full_network_name()), endburst_delay=3)
         except (RuntimeError, ValueError):  # Network not initialized yet, or a server name conflict.
@@ -326,7 +326,7 @@ def spawn_relay_user(irc, remoteirc, user, times_tagged=0):
         realhost = None
         ip = '0.0.0.0'
 
-    u = remoteirc.spawnClient(nick, ident=ident, host=host, realname=realname, modes=modes,
+    u = remoteirc.spawn_client(nick, ident=ident, host=host, realname=realname, modes=modes,
                                     opertype=opertype, server=rsid, ip=ip, realhost=realhost).uid
     try:
         remoteirc.users[u].remote = (irc.name, user)
@@ -477,7 +477,7 @@ def initialize_channel(irc, channel):
             # Only update the topic if it's different from what we already have,
             # and topic bursting is complete.
             if remoteirc.channels[remotechan].topicset and topic != irc.channels[channel].topic:
-                irc.topicBurst(irc.sid, channel, topic)
+                irc.topic_burst(irc.sid, channel, topic)
 
         # Send our users and channel modes to the other nets
         relay_joins(irc, channel, irc.channels[channel].users, irc.channels[channel].ts)
@@ -1291,7 +1291,7 @@ def handle_chgclient(irc, source, command, args):
                     newtext = normalize_host(remoteirc, text)
                 else:  # Don't overwrite the original text variable on every iteration.
                     newtext = text
-                remoteirc.updateClient(user, field, newtext)
+                remoteirc.update_client(user, field, newtext)
             except NotImplementedError:  # IRCd doesn't support changing the field we want
                 log.debug('(%s) relay.handle_chgclient: Ignoring changing field %r of %s on %s (for %s/%s);'
                           ' remote IRCd doesn\'t support it', irc.name, field,
@@ -1372,9 +1372,9 @@ def handle_topic(irc, numeric, command, args):
                 remoteirc.topic(remoteuser, remotechan, topic)
             else:
                 rsid = get_remote_sid(remoteirc, irc)
-                remoteirc.topicBurst(rsid, remotechan, topic)
+                remoteirc.topic_burst(rsid, remotechan, topic)
     elif oldtopic:  # Topic change blocked by claim.
-        irc.topicBurst(irc.sid, channel, oldtopic)
+        irc.topic_burst(irc.sid, channel, oldtopic)
 
 utils.add_hook(handle_topic, 'TOPIC')
 

--- a/plugins/relay.py
+++ b/plugins/relay.py
@@ -480,7 +480,6 @@ def initialize_channel(irc, channel):
                 irc.topicBurst(irc.sid, channel, topic)
 
         # Send our users and channel modes to the other nets
-        log.debug('(%s) relay.initialize_channel: joining our (%s) users: %s', irc.name, remotenet, irc.channels[channel].users)
         relay_joins(irc, channel, irc.channels[channel].users, irc.channels[channel].ts)
 
         if 'pylink' in world.services:

--- a/plugins/relay.py
+++ b/plugins/relay.py
@@ -117,7 +117,7 @@ def normalize_nick(irc, netname, nick, times_tagged=0, uid=''):
     # Charybdis, IRCu, etc. don't allow / in nicks, and will SQUIT with a protocol
     # violation if it sees one. Or it might just ignore the client introduction and
     # cause bad desyncs.
-    protocol_allows_slashes = irc.proto.hasCap('slash-in-nicks') or \
+    protocol_allows_slashes = irc.hasCap('slash-in-nicks') or \
         irc.serverdata.get('relay_force_slashes')
 
     if '/' not in separator or not protocol_allows_slashes:
@@ -176,11 +176,11 @@ def normalize_host(irc, host):
     log.debug('(%s) relay.normalize_host: IRCd=%s, host=%s', irc.name, irc.protoname, host)
 
     allowed_chars = string.ascii_letters + string.digits + '-.:'
-    if irc.proto.hasCap('slash-in-hosts'):
+    if irc.hasCap('slash-in-hosts'):
         # UnrealIRCd and IRCd-Hybrid don't allow slashes in hostnames
         allowed_chars += '/'
 
-    if irc.proto.hasCap('underscore-in-hosts'):
+    if irc.hasCap('underscore-in-hosts'):
         # Most IRCds allow _ in hostnames, but hybrid/charybdis/ratbox IRCds do not.
         allowed_chars += '_'
 
@@ -219,7 +219,7 @@ def spawn_relay_server(irc, remoteirc):
             suffix = conf.conf.get('relay', {}).get('server_suffix', 'relay')
             # Strip any leading or trailing .'s
             suffix = suffix.strip('.')
-            sid = irc.proto.spawnServer('%s.%s' % (remoteirc.name, suffix),
+            sid = irc.spawnServer('%s.%s' % (remoteirc.name, suffix),
                                         desc="PyLink Relay network - %s" %
                                         (remoteirc.getFullNetworkName()), endburst_delay=3)
         except (RuntimeError, ValueError):  # Network not initialized yet, or a server name conflict.
@@ -326,14 +326,14 @@ def spawn_relay_user(irc, remoteirc, user, times_tagged=0):
         realhost = None
         ip = '0.0.0.0'
 
-    u = remoteirc.proto.spawnClient(nick, ident=ident, host=host, realname=realname, modes=modes,
+    u = remoteirc.spawnClient(nick, ident=ident, host=host, realname=realname, modes=modes,
                                     opertype=opertype, server=rsid, ip=ip, realhost=realhost).uid
     try:
         remoteirc.users[u].remote = (irc.name, user)
         remoteirc.users[u].opertype = opertype
         away = userobj.away
         if away:
-            remoteirc.proto.away(u, away)
+            remoteirc.away(u, away)
     except KeyError:
         # User got killed somehow while we were setting options on it.
         # This is probably being done by the uplink, due to something like an
@@ -477,7 +477,7 @@ def initialize_channel(irc, channel):
             # Only update the topic if it's different from what we already have,
             # and topic bursting is complete.
             if remoteirc.channels[remotechan].topicset and topic != irc.channels[channel].topic:
-                irc.proto.topicBurst(irc.sid, channel, topic)
+                irc.topicBurst(irc.sid, channel, topic)
 
         # Send our users and channel modes to the other nets
         log.debug('(%s) relay.initialize_channel: joining our (%s) users: %s', irc.name, remotenet, irc.channels[channel].users)
@@ -494,7 +494,7 @@ def remove_channel(irc, channel):
     if channel not in map(str.lower, irc.serverdata.get('channels', [])):
         world.services['pylink'].extra_channels[irc.name].discard(channel)
         if irc.pseudoclient:
-            irc.proto.part(irc.pseudoclient.uid, channel, 'Channel delinked.')
+            irc.part(irc.pseudoclient.uid, channel, 'Channel delinked.')
 
     relay = get_relay((irc.name, channel))
     if relay:
@@ -506,12 +506,12 @@ def remove_channel(irc, channel):
                 if user == irc.pseudoclient.uid and channel in \
                         irc.serverdata.get('channels', []):
                     continue
-                irc.proto.part(user, channel, 'Channel delinked.')
+                irc.part(user, channel, 'Channel delinked.')
                 # Don't ever quit it either...
                 if user != irc.pseudoclient.uid and not irc.users[user].channels:
                     remoteuser = get_orig_user(irc, user)
                     del relayusers[remoteuser][irc.name]
-                    irc.proto.quit(user, 'Left all shared channels.')
+                    irc.quit(user, 'Left all shared channels.')
 
 def check_claim(irc, channel, sender, chanobj=None):
     """
@@ -648,7 +648,7 @@ def relay_joins(irc, channel, users, ts, burst=True):
 
                 # Fetch the known channel TS and all the prefix modes for each user. This ensures
                 # the different sides of the relay are merged properly.
-                if not irc.proto.hasCap('has-ts'):
+                if not irc.hasCap('has-ts'):
                     # Special hack for clientbot: just use the remote's modes so mode changes
                     # take precendence. (TS is always outside the clientbot's control)
                     ts = remoteirc.channels[remotechan].ts
@@ -668,10 +668,10 @@ def relay_joins(irc, channel, users, ts, burst=True):
                 modes = get_supported_cmodes(irc, remoteirc, channel, irc.channels[channel].modes)
                 rsid = get_remote_sid(remoteirc, irc)
                 if rsid:
-                    remoteirc.proto.sjoin(rsid, remotechan, queued_users, ts=ts, modes=modes)
+                    remoteirc.sjoin(rsid, remotechan, queued_users, ts=ts, modes=modes)
             else:
                 # A regular JOIN only needs the user and the channel. TS, source SID, etc., can all be omitted.
-                remoteirc.proto.join(queued_users[0][1], remotechan)
+                remoteirc.join(queued_users[0][1], remotechan)
 
             joined_nets[remoteirc] = {'channel': remotechan, 'users': [u[-1] for u in queued_users]}
 
@@ -701,11 +701,11 @@ def relay_part(irc, channel, user):
             continue
 
         # Part the relay client with the channel delinked message.
-        remoteirc.proto.part(remoteuser, remotechan, 'Channel delinked.')
+        remoteirc.part(remoteuser, remotechan, 'Channel delinked.')
 
         # If the relay client no longer has any channels, quit them to prevent inflating /lusers.
         if isRelayClient(remoteirc, remoteuser) and not remoteirc.users[remoteuser].channels:
-            remoteirc.proto.quit(remoteuser, 'Left all shared channels.')
+            remoteirc.quit(remoteuser, 'Left all shared channels.')
             del relayusers[(irc.name, user)][remoteirc.name]
 
 
@@ -783,7 +783,7 @@ def get_supported_cmodes(irc, remoteirc, channel, modes):
                               "for network %r.",
                               irc.name, modechar, arg, remoteirc.name)
 
-                    if (not irc.proto.hasCap('can-spawn-clients')) and irc.pseudoclient and arg == irc.pseudoclient.uid:
+                    if (not irc.hasCap('can-spawn-clients')) and irc.pseudoclient and arg == irc.pseudoclient.uid:
                         # Skip modesync on the main PyLink client.
                         log.debug("(%s) relay.get_supported_cmodes: filtering prefix change (%r, %r) on Clientbot relayer",
                                   irc.name, name, arg)
@@ -848,7 +848,7 @@ def handle_relay_whois(irc, source, command, args):
         """Convenience wrapper to return WHOIS replies."""
         # WHOIS replies are by convention prefixed with the target user's nick.
         text = '%s %s' % (targetuser.nick, text)
-        irc.proto.numeric(server, num, source, text)
+        irc.numeric(server, num, source, text)
 
     def checkSendKey(infoline):
         """
@@ -876,7 +876,7 @@ def handle_relay_whois(irc, source, command, args):
             # Send account information if told to and the target is logged in.
             wreply(330, "%s :is logged in (on %s) as" % (realuser.services_account, netname))
 
-        if checkSendKey('whois_show_server') and realirc.proto.hasCap('can-track-servers'):
+        if checkSendKey('whois_show_server') and realirc.hasCap('can-track-servers'):
             wreply(320, ":is actually connected via the following server:")
             realserver = realirc.getServer(uid)
             realserver = realirc.servers[realserver]
@@ -936,7 +936,7 @@ def handle_join(irc, numeric, command, args):
 
         if modes:
             log.debug('(%s) relay.handle_join: reverting modes on BURST: %s', irc.name, irc.joinModes(modes))
-            irc.proto.mode(irc.sid, channel, modes)
+            irc.mode(irc.sid, channel, modes)
 
     relay_joins(irc, channel, users, ts, burst=False)
 utils.add_hook(handle_join, 'JOIN')
@@ -950,7 +950,7 @@ def handle_quit(irc, numeric, command, args):
         for netname, user in relayusers[(irc.name, numeric)].copy().items():
             remoteirc = world.networkobjects[netname]
             try:  # Try to quit the client. If this fails because they're missing, bail.
-                remoteirc.proto.quit(user, args['text'])
+                remoteirc.quit(user, args['text'])
             except LookupError:
                 pass
         del relayusers[(irc.name, numeric)]
@@ -1007,7 +1007,7 @@ def handle_nick(irc, numeric, command, args):
         remoteirc = world.networkobjects[netname]
         newnick = normalize_nick(remoteirc, irc.name, args['newnick'], uid=user)
         if remoteirc.users[user].nick != newnick:
-            remoteirc.proto.nick(user, newnick)
+            remoteirc.nick(user, newnick)
 utils.add_hook(handle_nick, 'NICK')
 
 def handle_part(irc, numeric, command, args):
@@ -1017,14 +1017,14 @@ def handle_part(irc, numeric, command, args):
     if numeric == irc.pseudoclient.uid:
         # For clientbot: treat forced parts to the bot as clearchan, and attempt to rejoin only
         # if it affected a relay.
-        if not irc.proto.hasCap('can-spawn-clients'):
+        if not irc.hasCap('can-spawn-clients'):
             for channel in [c for c in channels if get_relay((irc.name, c))]:
                 for user in irc.channels[channel].users:
                     if (not irc.isInternalClient(user)) and (not isRelayClient(irc, user)):
                         irc.callHooks([irc.sid, 'CLIENTBOT_SERVICE_KICKED', {'channel': channel, 'target': user,
                                        'text': 'Clientbot was force parted (Reason: %s)' % text or 'None',
                                        'parse_as': 'KICK'}])
-                irc.proto.join(irc.pseudoclient.uid, channel)
+                irc.join(irc.pseudoclient.uid, channel)
 
             return
         return
@@ -1035,9 +1035,9 @@ def handle_part(irc, numeric, command, args):
             remotechan = get_remote_channel(irc, remoteirc, channel)
             if remotechan is None:
                 continue
-            remoteirc.proto.part(user, remotechan, text)
+            remoteirc.part(user, remotechan, text)
             if not remoteirc.users[user].channels:
-                remoteirc.proto.quit(user, 'Left all shared channels.')
+                remoteirc.quit(user, 'Left all shared channels.')
                 del relayusers[(irc.name, numeric)][remoteirc.name]
 utils.add_hook(handle_part, 'PART')
 
@@ -1120,9 +1120,9 @@ def handle_messages(irc, numeric, command, args):
 
             try:
                 if notice:
-                    remoteirc.proto.notice(user, real_target, real_text)
+                    remoteirc.notice(user, real_target, real_text)
                 else:
-                    remoteirc.proto.message(user, real_target, real_text)
+                    remoteirc.message(user, real_target, real_text)
             except LookupError:
                 # Our relay clone disappeared while we were trying to send the message.
                 # This is normally due to a nick conflict with the IRCd.
@@ -1149,7 +1149,7 @@ def handle_messages(irc, numeric, command, args):
             return
         remoteirc = world.networkobjects[homenet]
 
-        if (not remoteirc.proto.hasCap('can-spawn-clients')) and not conf.conf.get('relay', {}).get('allow_clientbot_pms'):
+        if (not remoteirc.hasCap('can-spawn-clients')) and not conf.conf.get('relay', {}).get('allow_clientbot_pms'):
             irc.msg(numeric, 'Private messages to users connected via Clientbot have '
                     'been administratively disabled.', notice=True)
             return
@@ -1158,9 +1158,9 @@ def handle_messages(irc, numeric, command, args):
 
         try:
             if notice:
-                remoteirc.proto.notice(user, real_target, text)
+                remoteirc.notice(user, real_target, text)
             else:
-                remoteirc.proto.message(user, real_target, text)
+                remoteirc.message(user, real_target, text)
         except LookupError:
             # Our relay clone disappeared while we were trying to send the message.
             # This is normally due to a nick conflict with the IRCd.
@@ -1180,7 +1180,7 @@ def handle_kick(irc, source, command, args):
     relay = get_relay((irc.name, channel))
 
     # Special case for clientbot: treat kicks to the PyLink service bot as channel clear.
-    if (not irc.proto.hasCap('can-spawn-clients')) and irc.pseudoclient and target == irc.pseudoclient.uid:
+    if (not irc.hasCap('can-spawn-clients')) and irc.pseudoclient and target == irc.pseudoclient.uid:
         for user in irc.channels[channel].users:
             if (not irc.isInternalClient(user)) and (not isRelayClient(irc, user)):
                 reason = "Clientbot kicked by %s (Reason: %s)" % (irc.getFriendlyName(source), text)
@@ -1222,7 +1222,7 @@ def handle_kick(irc, source, command, args):
                 # kick ops, admins can't kick owners, etc.
                 modes = get_prefix_modes(remoteirc, irc, remotechan, real_target)
                 # Join the kicked client back with its respective modes.
-                irc.proto.sjoin(irc.sid, channel, [(modes, target)])
+                irc.sjoin(irc.sid, channel, [(modes, target)])
                 if kicker in irc.users:
                     log.info('(%s) relay: Blocked KICK (reason %r) from %s/%s to relay client %s on %s.',
                              irc.name, args['text'], irc.users[source].nick, irc.name,
@@ -1241,13 +1241,13 @@ def handle_kick(irc, source, command, args):
         # Propogate the kick!
         if real_kicker:
             log.debug('(%s) relay.handle_kick: Kicking %s from channel %s via %s on behalf of %s/%s', irc.name, real_target, remotechan,real_kicker, kicker, irc.name)
-            remoteirc.proto.kick(real_kicker, remotechan, real_target, args['text'])
+            remoteirc.kick(real_kicker, remotechan, real_target, args['text'])
         else:
             # Kick originated from a server, or the kicker isn't in any
             # common channels with the target relay network.
             rsid = get_remote_sid(remoteirc, irc)
             log.debug('(%s) relay.handle_kick: Kicking %s from channel %s via %s on behalf of %s/%s', irc.name, real_target, remotechan, rsid, kicker, irc.name)
-            if not irc.proto.hasCap('can-spawn-clients'):
+            if not irc.hasCap('can-spawn-clients'):
                 # Special case for clientbot: no kick prefixes are needed.
                 text = args['text']
             else:
@@ -1260,16 +1260,16 @@ def handle_kick(irc, source, command, args):
                 except AttributeError:
                     text = "(<unknown kicker>@%s) %s" % (irc.name, args['text'])
             rsid = rsid or remoteirc.sid  # Fall back to the main PyLink SID if get_remote_sid() fails
-            remoteirc.proto.kick(rsid, remotechan, real_target, text)
+            remoteirc.kick(rsid, remotechan, real_target, text)
 
         # If the target isn't on any channels, quit them.
         if remoteirc != irc and (not remoteirc.users[real_target].channels) and not origuser:
             del relayusers[(irc.name, target)][remoteirc.name]
-            remoteirc.proto.quit(real_target, 'Left all shared channels.')
+            remoteirc.quit(real_target, 'Left all shared channels.')
 
     if origuser and not irc.users[target].channels:
         del relayusers[origuser][irc.name]
-        irc.proto.quit(target, 'Left all shared channels.')
+        irc.quit(target, 'Left all shared channels.')
 
 utils.add_hook(handle_kick, 'KICK')
 
@@ -1292,7 +1292,7 @@ def handle_chgclient(irc, source, command, args):
                     newtext = normalize_host(remoteirc, text)
                 else:  # Don't overwrite the original text variable on every iteration.
                     newtext = text
-                remoteirc.proto.updateClient(user, field, newtext)
+                remoteirc.updateClient(user, field, newtext)
             except NotImplementedError:  # IRCd doesn't support changing the field we want
                 log.debug('(%s) relay.handle_chgclient: Ignoring changing field %r of %s on %s (for %s/%s);'
                           ' remote IRCd doesn\'t support it', irc.name, field,
@@ -1322,17 +1322,17 @@ def handle_mode(irc, numeric, command, args):
                     # from the corresponding server.
                     u = get_remote_user(irc, remoteirc, numeric, spawn_if_missing=False)
                     if u:
-                        remoteirc.proto.mode(u, remotechan, supported_modes)
+                        remoteirc.mode(u, remotechan, supported_modes)
                     else:
                         rsid = get_remote_sid(remoteirc, irc)
                         rsid = rsid or remoteirc.sid
-                        remoteirc.proto.mode(rsid, remotechan, supported_modes)
+                        remoteirc.mode(rsid, remotechan, supported_modes)
             else:  # Mode change blocked by CLAIM.
                 reversed_modes = irc.reverseModes(target, modes, oldobj=oldchan)
                 log.debug('(%s) relay.handle_mode: Reversing mode changes of %r with %r (CLAIM).',
                           irc.name, modes, reversed_modes)
                 if reversed_modes:
-                    irc.proto.mode(irc.sid, target, reversed_modes)
+                    irc.mode(irc.sid, target, reversed_modes)
                 break
 
         else:
@@ -1350,7 +1350,7 @@ def handle_mode(irc, numeric, command, args):
             remoteuser = get_remote_user(irc, remoteirc, target, spawn_if_missing=False)
 
             if remoteuser and modes:
-                remoteirc.proto.mode(remoteuser, remoteuser, modes)
+                remoteirc.mode(remoteuser, remoteuser, modes)
 
 utils.add_hook(handle_mode, 'MODE')
 
@@ -1370,12 +1370,12 @@ def handle_topic(irc, numeric, command, args):
             # This might originate from a server too.
             remoteuser = get_remote_user(irc, remoteirc, numeric, spawn_if_missing=False)
             if remoteuser:
-                remoteirc.proto.topic(remoteuser, remotechan, topic)
+                remoteirc.topic(remoteuser, remotechan, topic)
             else:
                 rsid = get_remote_sid(remoteirc, irc)
-                remoteirc.proto.topicBurst(rsid, remotechan, topic)
+                remoteirc.topicBurst(rsid, remotechan, topic)
     elif oldtopic:  # Topic change blocked by claim.
-        irc.proto.topicBurst(irc.sid, channel, oldtopic)
+        irc.topicBurst(irc.sid, channel, oldtopic)
 
 utils.add_hook(handle_topic, 'TOPIC')
 
@@ -1403,7 +1403,7 @@ def handle_kill(irc, numeric, command, args):
                 modes = get_prefix_modes(remoteirc, irc, remotechan, realuser[1])
                 log.debug('(%s) relay.handle_kill: userpair: %s, %s', irc.name, modes, realuser)
                 client = get_remote_user(remoteirc, irc, realuser[1], times_tagged=1)
-                irc.proto.sjoin(get_remote_sid(irc, remoteirc), localchan, [(modes, client)])
+                irc.sjoin(get_remote_sid(irc, remoteirc), localchan, [(modes, client)])
 
         if userdata and numeric in irc.users:
             log.info('(%s) relay.handle_kill: Blocked KILL (reason %r) from %s to relay client %s/%s.',
@@ -1432,7 +1432,7 @@ utils.add_hook(handle_kill, 'KILL')
 def handle_away(irc, numeric, command, args):
     for netname, user in relayusers[(irc.name, numeric)].items():
         remoteirc = world.networkobjects[netname]
-        remoteirc.proto.away(user, args['text'])
+        remoteirc.away(user, args['text'])
 utils.add_hook(handle_away, 'AWAY')
 
 def handle_invite(irc, source, command, args):
@@ -1453,7 +1453,7 @@ def handle_invite(irc, source, command, args):
                                    'channel not on their network!',
                                    notice=True)
         else:
-            remoteirc.proto.invite(remotesource, remoteuser,
+            remoteirc.invite(remotesource, remoteuser,
                                          remotechan)
 utils.add_hook(handle_invite, 'INVITE')
 
@@ -1540,7 +1540,7 @@ def nick_collide(irc, target):
     newnick = normalize_nick(irc, remotenet, nick, times_tagged=1)
     log.debug('(%s) relay.nick_collide: Fixing nick of relay client %r (%s) to %s',
               irc.name, target, nick, newnick)
-    irc.proto.nick(target, newnick)
+    irc.nick(target, newnick)
 
 def handle_save(irc, numeric, command, args):
     target = args['target']
@@ -1582,7 +1582,7 @@ def create(irc, source, args):
     if not utils.isChannel(channel):
         irc.error('Invalid channel %r.' % channel)
         return
-    if not irc.proto.hasCap('can-host-relay'):
+    if not irc.hasCap('can-host-relay'):
         irc.error('Clientbot networks cannot be used to host a relay.')
         return
     if source not in irc.channels[channel].users:
@@ -1723,7 +1723,7 @@ def link(irc, source, args):
             # Special case for Clientbot: join the requested channel first, then
             # require that the caller be opped.
             if localchan not in irc.pseudoclient.channels:
-                irc.proto.join(irc.pseudoclient.uid, localchan)
+                irc.join(irc.pseudoclient.uid, localchan)
                 irc.reply('Joining %r now to check for op status; please run this command again after I join.' % localchan)
                 return
             elif not irc.channels[localchan].isOpPlus(source):
@@ -1774,7 +1774,7 @@ def link(irc, source, args):
 
             our_ts = irc.channels[localchan].ts
             their_ts = world.networkobjects[remotenet].channels[channel].ts
-            if (our_ts < their_ts) and irc.proto.hasCap('has-ts'):
+            if (our_ts < their_ts) and irc.hasCap('has-ts'):
                 log.debug('(%s) relay: Blocking link request %s%s -> %s%s due to bad TS (%s < %s)', irc.name,
                           irc.name, localchan, remotenet, args.channel, our_ts, their_ts)
                 irc.error("The channel creation date (TS) on %s (%s) is lower than the target "

--- a/plugins/relay_clientbot.py
+++ b/plugins/relay_clientbot.py
@@ -45,7 +45,7 @@ def cb_relay_core(irc, source, command, args):
 
     if irc.pseudoclient and relay:
         try:
-            sourcename = irc.getFriendlyName(source)
+            sourcename = irc.get_friendly_name(source)
         except KeyError:  # User has left due to /quit
             sourcename = args['userdata'].nick
 
@@ -87,7 +87,7 @@ def cb_relay_core(irc, source, command, args):
         text_template = string.Template(text_template)
 
         if text_template:
-            if irc.getServiceBot(source):
+            if irc.get_service_bot(source):
                 # HACK: service bots are global and lack the relay state we look for.
                 # just pretend the message comes from the current network.
                 log.debug('(%s) relay_cb_core: Overriding network origin to local (source=%s)', irc.name, source)
@@ -131,7 +131,7 @@ def cb_relay_core(irc, source, command, args):
 
             if source in irc.users:
                 try:
-                    identhost = irc.getHostmask(source).split('!')[-1]
+                    identhost = irc.get_hostmask(source).split('!')[-1]
                 except KeyError:  # User got removed due to quit
                     identhost = '%s@%s' % (args['olduser'].ident, args['olduser'].host)
                 # This is specifically spaced so that ident@host is only shown for users that have
@@ -142,7 +142,7 @@ def cb_relay_core(irc, source, command, args):
 
             # $target_nick: Convert the target for kicks, etc. from a UID to a nick
             if args.get("target") in irc.users:
-                args["target_nick"] = irc.getFriendlyName(args['target'])
+                args["target_nick"] = irc.get_friendly_name(args['target'])
 
             args.update({'netname': netname, 'sender': sourcename, 'sender_identhost': identhost,
                          'colored_sender': color_text(sourcename), 'colored_netname': color_text(netname)})
@@ -204,7 +204,7 @@ def rpm(irc, source, args):
         return
 
     relay = world.plugins.get('relay')
-    if irc.hasCap('can-spawn-clients'):
+    if irc.has_cap('can-spawn-clients'):
         irc.error('This command is only supported on Clientbot networks. Try /msg %s <text>' % target)
         return
     elif relay is None:
@@ -218,7 +218,7 @@ def rpm(irc, source, args):
                   'administratively disabled.')
         return
 
-    uid = irc.nickToUid(target)
+    uid = irc.nick_to_uid(target)
     if not uid:
         irc.error('Unknown user %s.' % target)
         return
@@ -226,7 +226,7 @@ def rpm(irc, source, args):
         irc.error('%s is not a relay user.' % target)
         return
     else:
-        assert not irc.isInternalClient(source), "rpm is not allowed from PyLink bots"
+        assert not irc.is_internal_client(source), "rpm is not allowed from PyLink bots"
         # Send the message through relay by faking a hook for its handler.
         relay.handle_messages(irc, source, 'RELAY_CLIENTBOT_PRIVMSG', {'target': uid, 'text': text})
         irc.reply('Message sent.')

--- a/plugins/relay_clientbot.py
+++ b/plugins/relay_clientbot.py
@@ -204,7 +204,7 @@ def rpm(irc, source, args):
         return
 
     relay = world.plugins.get('relay')
-    if irc.proto.hasCap('can-spawn-clients'):
+    if irc.hasCap('can-spawn-clients'):
         irc.error('This command is only supported on Clientbot networks. Try /msg %s <text>' % target)
         return
     elif relay is None:

--- a/plugins/servermaps.py
+++ b/plugins/servermaps.py
@@ -78,7 +78,7 @@ def _map(irc, source, args, show_relay=True):
                 # This is a relay server - display the remote map of the network it represents
                 relay_server = serverlist[leaf].remote
                 remoteirc = world.networkobjects[relay_server]
-                if remoteirc.proto.hasCap('can-track-servers'):
+                if remoteirc.hasCap('can-track-servers'):
                     # Only ever show relay subservers once - this prevents infinite loops.
                     showall(remoteirc, remoteirc.sid, hops=hops, is_relay_server=True)
 

--- a/plugins/servermaps.py
+++ b/plugins/servermaps.py
@@ -78,7 +78,7 @@ def _map(irc, source, args, show_relay=True):
                 # This is a relay server - display the remote map of the network it represents
                 relay_server = serverlist[leaf].remote
                 remoteirc = world.networkobjects[relay_server]
-                if remoteirc.hasCap('can-track-servers'):
+                if remoteirc.has_cap('can-track-servers'):
                     # Only ever show relay subservers once - this prevents infinite loops.
                     showall(remoteirc, remoteirc.sid, hops=hops, is_relay_server=True)
 

--- a/plugins/servprotect.py
+++ b/plugins/servprotect.py
@@ -18,7 +18,7 @@ def handle_kill(irc, numeric, command, args):
     automatically disconnects from the network.
     """
 
-    if (args['userdata'] and irc.isInternalServer(args['userdata'].server)) or irc.isInternalClient(args['target']):
+    if (args['userdata'] and irc.is_internal_server(args['userdata'].server)) or irc.is_internal_client(args['target']):
         if killcache.setdefault(irc.name, 1) >= length:
             log.error('(%s) servprotect: Too many kills received, aborting!', irc.name)
             irc.disconnect()
@@ -33,7 +33,7 @@ def handle_save(irc, numeric, command, args):
     Tracks SAVEs (nick collision) against PyLink clients. If too many are received,
     automatically disconnects from the network.
     """
-    if irc.isInternalClient(args['target']):
+    if irc.is_internal_client(args['target']):
         if savecache.setdefault(irc.name, 0) >= length:
             log.error('(%s) servprotect: Too many nick collisions, aborting!', irc.name)
             irc.disconnect()

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -404,7 +404,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # pseudo-uids and pseudo-sids as we see prefixes.
             if ('!' not in sender) and '.' in sender:
                 # Sender is a server name. XXX: make this check more foolproof
-                idsource = self._getSid(sender)
+                idsource = self._get_SID(sender)
                 if idsource not in self.irc.servers:
                     idsource = self.spawnServer(sender, internal=False)
             else:

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -271,7 +271,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
     def quit(self, source, reason):
         """STUB: Quits a client."""
         userdata = self.users[source]
-        self.removeClient(source)
+        self._remove_client(source)
         self.callHooks([source, 'CLIENTBOT_QUIT', {'text': reason, 'userdata': userdata}])
 
     def sjoin(self, server, channel, users, ts=None, modes=set()):

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -259,7 +259,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
 
     def part(self, source, channel, reason=''):
         """STUB: Parts a user from a channel."""
-        self.channels[channel].removeuser(source)
+        self.channels[channel].remove_user(source)
         self.users[source].channels.discard(channel)
 
         # Only parts for the main PyLink client are actually forwarded. Others are ignored.
@@ -818,7 +818,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                 del self.kick_queue[channel]
 
         # Statekeeping: remove the target from the channel they were previously in.
-        self.channels[channel].removeuser(target)
+        self.channels[channel].remove_user(target)
         try:
             self.users[target].channels.remove(channel)
         except KeyError:
@@ -907,7 +907,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             reason = ''
 
         for channel in channels:
-            self.channels[channel].removeuser(source)
+            self.channels[channel].remove_user(source)
         self.users[source].channels -= set(channels)
 
         self.call_hooks([source, 'PART', {'channels': channels, 'text': reason}])

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -117,7 +117,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
 
         return u
 
-    def spawnServer(self, name, sid=None, uplink=None, desc=None, endburst_delay=0, internal=True):
+    def spawn_server(self, name, sid=None, uplink=None, desc=None, endburst_delay=0, internal=True):
         """
         STUB: Pretends to spawn a new server with a subset of the given options.
         """
@@ -406,7 +406,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                 # Sender is a server name. XXX: make this check more foolproof
                 idsource = self._get_SID(sender)
                 if idsource not in self.servers:
-                    idsource = self.spawnServer(sender, internal=False)
+                    idsource = self.spawn_server(sender, internal=False)
             else:
                 # Sender is a either a nick or a nick!user@host prefix. Split it into its relevant parts.
                 try:

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -303,7 +303,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
     def _stub(self, *args):
         """Stub outgoing command function (does nothing)."""
         return
-    kill = topic = topicBurst = knock = numeric = _stub
+    kill = topic = topic_burst = knock = numeric = _stub
 
     def updateClient(self, target, field, text):
         """Updates the known ident, host, or realname of a client."""

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -372,7 +372,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                 tag = tag.replace(r'\:', ';')
                 tagdata[idx] = tag
 
-            results = self.parseCapabilities(tagdata, fallback=None)
+            results = self.parse_isupport(tagdata, fallback=None)
             log.debug('(%s) parsed message tags %s', self.name, results)
             return results
         return {}
@@ -387,14 +387,14 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             data = data[1:]
 
         try:
-            args = self.parsePrefixedArgs(data)
+            args = self.parse_prefixed_args(data)
             sender = args[0]
             command = args[1]
             args = args[2:]
 
         except IndexError:
             # Raw command without an explicit sender; assume it's being sent by our uplink.
-            args = self.parseArgs(data)
+            args = self.parse_args(data)
             idsource = sender = self.uplink
             command = args[0]
             args = args[1:]
@@ -528,7 +528,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # Server: CAP * LS * :cap-notify server-time example.org/dummy-cap=dummyvalue example.org/second-dummy-cap
             # Server: CAP * LS :userhost-in-names sasl=EXTERNAL,DH-AES,DH-BLOWFISH,ECDSA-NIST256P-CHALLENGE,PLAIN
             log.debug('(%s) Got new capabilities %s', self.name, args[-1])
-            self.ircv3_caps_available.update(self.parseCapabilities(args[-1], None))
+            self.ircv3_caps_available.update(self.parse_isupport(args[-1], None))
             if args[2] != '*':
                 self.requestNewCaps()
 
@@ -554,7 +554,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # Note: CAP NEW allows capabilities with values (e.g. sasl=mech1,mech2), while CAP DEL
             # does not.
             log.debug('(%s) Got new capabilities %s', self.name, args[-1])
-            newcaps = self.parseCapabilities(args[-1], None)
+            newcaps = self.parse_isupport(args[-1], None)
             self.ircv3_caps_available.update(newcaps)
             self.requestNewCaps()
 
@@ -582,7 +582,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         """
         Handles 005 / RPL_ISUPPORT.
         """
-        self.caps.update(self.parseCapabilities(args[1:-1]))
+        self.caps.update(self.parse_isupport(args[1:-1]))
         log.debug('(%s) handle_005: self.caps is %s', self.name, self.caps)
 
         if 'CHANMODES' in self.caps:
@@ -599,7 +599,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         log.debug('(%s) handle_005: casemapping set to %s', self.name, self.casemapping)
 
         if 'PREFIX' in self.caps:
-            self.prefixmodes = prefixmodes = self.parsePrefixes(self.caps['PREFIX'])
+            self.prefixmodes = prefixmodes = self.parse_isupport_prefixes(self.caps['PREFIX'])
             log.debug('(%s) handle_005: prefix modes set to %s', self.name, self.prefixmodes)
 
             # Autodetect common prefix mode names.

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -305,10 +305,10 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         return
     kill = topic = topic_burst = knock = numeric = _stub
 
-    def updateClient(self, target, field, text):
+    def update_client(self, target, field, text):
         """Updates the known ident, host, or realname of a client."""
         if target not in self.users:
-            log.warning("(%s) Unknown target %s for updateClient()", self.name, target)
+            log.warning("(%s) Unknown target %s for update_client()", self.name, target)
             return
 
         u = self.users[target]
@@ -711,9 +711,9 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             log.debug("(%s) Ignoring extraneous /WHO info for %s", self.name, nick)
             return
 
-        self.updateClient(uid, 'IDENT', ident)
-        self.updateClient(uid, 'HOST', host)
-        self.updateClient(uid, 'GECOS', realname)
+        self.update_client(uid, 'IDENT', ident)
+        self.update_client(uid, 'HOST', host)
+        self.update_client(uid, 'GECOS', realname)
 
         # The status given uses the following letters: <H|G>[*][@|+]
         # H means here (not marked /away)

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -333,7 +333,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         else:
             return  # Nothing changed
 
-    def _getUid(self, nick, ident=None, host=None):
+    def _get_UID(self, nick, ident=None, host=None):
         """
         Fetches the UID for the given nick, creating one if it does not already exist.
 
@@ -414,7 +414,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                 except ValueError:
                     ident = host = None  # Set ident and host as null for now.
                     nick = sender  # Treat the sender prefix we received as a nick.
-                idsource = self._getUid(nick, ident, host)
+                idsource = self._get_UID(nick, ident, host)
 
         try:
             func = getattr(self, 'handle_'+command.lower())
@@ -649,7 +649,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # Get the PUID for the given nick. If one doesn't exist, spawn
             # a new virtual user. TODO: wait for WHO responses for each nick before
             # spawning in order to get a real ident/host.
-            idsource = self._getUid(nick)
+            idsource = self._get_UID(nick)
 
             # Queue these virtual users to be joined if they're not already in the channel,
             # or we're waiting for a kick acknowledgment for them.

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -10,7 +10,7 @@ FALLBACK_REALNAME = 'PyLink Relay Mirror Client'
 COMMON_PREFIXMODES = [('h', 'halfop'), ('a', 'admin'), ('q', 'owner'), ('y', 'owner')]
 IRCV3_CAPABILITIES = {'multi-prefix', 'sasl'}
 
-class ClientbotWrapperProtocol(Protocol):
+class ClientbotWrapperProtocol(IRCCommonProtocol):
     def __init__(self, irc):
         super().__init__(irc)
 

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -4,7 +4,7 @@ import base64
 
 from pylinkirc import utils, conf
 from pylinkirc.log import log
-from pylinkirc.classes import Protocol, User, IrcServer, ProtocolError
+from pylinkirc.classes import Protocol, User, Server, ProtocolError
 
 FALLBACK_REALNAME = 'PyLink Relay Mirror Client'
 COMMON_PREFIXMODES = [('h', 'halfop'), ('a', 'admin'), ('q', 'owner'), ('y', 'owner')]
@@ -123,7 +123,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         """
         name = name.lower()
         sid = self.sidgen.next_sid(prefix=name)
-        self.servers[sid] = IrcServer(uplink, name, internal=internal)
+        self.servers[sid] = Server(uplink, name, internal=internal)
         return sid
 
     def away(self, source, text):

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -87,7 +87,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         self._cap_timer.start()
 
         # This is a really gross hack to get the defined NICK/IDENT/HOST/GECOS.
-        # But this connection stuff is done before any of the spawnClient stuff in
+        # But this connection stuff is done before any of the spawn_client stuff in
         # services_support fires.
         self.conf_nick = self.serverdata.get('pylink_nick') or conf.conf["bot"].get("nick", "PyLink")
         f('NICK %s' % (self.conf_nick))
@@ -96,7 +96,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                               conf.conf["bot"].get("realname", "PyLink Clientbot")))
 
     # Note: clientbot clients are initialized with umode +i by default
-    def spawnClient(self, nick, ident='unknown', host='unknown.host', realhost=None, modes={('i', None)},
+    def spawn_client(self, nick, ident='unknown', host='unknown.host', realhost=None, modes={('i', None)},
             server=None, ip='0.0.0.0', realname='', ts=None, opertype=None,
             manipulatable=False):
         """
@@ -108,7 +108,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
 
         ts = ts or int(time.time())
 
-        log.debug('(%s) spawnClient stub called, saving nick %s as PUID %s', self.name, nick, uid)
+        log.debug('(%s) spawn_client stub called, saving nick %s as PUID %s', self.name, nick, uid)
         u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
                                           manipulatable=manipulatable, realhost=realhost, ip=ip)
         self.servers[server].users.add(uid)
@@ -351,7 +351,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                 log.debug('(%s) Nick-colliding virtual client %s/%s', self.name, idsource, nick)
                 self.call_hooks([self.sid, 'CLIENTBOT_NICKCOLLIDE', {'target': idsource, 'parse_as': 'SAVE'}])
 
-            idsource = self.spawnClient(nick, ident or 'unknown', host or 'unknown',
+            idsource = self.spawn_client(nick, ident or 'unknown', host or 'unknown',
                                         server=self.uplink, realname=FALLBACK_REALNAME).uid
 
         return idsource

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -4,7 +4,7 @@ import base64
 
 from pylinkirc import utils, conf
 from pylinkirc.log import log
-from pylinkirc.classes import Protocol, IrcUser, IrcServer, ProtocolError
+from pylinkirc.classes import Protocol, User, IrcServer, ProtocolError
 
 FALLBACK_REALNAME = 'PyLink Relay Mirror Client'
 COMMON_PREFIXMODES = [('h', 'halfop'), ('a', 'admin'), ('q', 'owner'), ('y', 'owner')]
@@ -109,7 +109,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         ts = ts or int(time.time())
 
         log.debug('(%s) spawn_client stub called, saving nick %s as PUID %s', self.name, nick, uid)
-        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        u = self.users[uid] = User(nick, ts, uid, server, ident=ident, host=host, realname=realname,
                                           manipulatable=manipulatable, realhost=realhost, ip=ip)
         self.servers[server].users.add(uid)
 

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -761,7 +761,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         for user in users:
             # Fill in prefix modes of everyone when doing mock SJOIN.
             try:
-                for mode in c.getPrefixModes(user):
+                for mode in c.get_prefix_modes(user):
                     modechar = self.cmodes.get(mode)
                     log.debug('(%s) handle_315: adding mode %s +%s %s', self.name, mode, modechar, user)
                     if modechar:

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -45,9 +45,9 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         """
         Returns the real nick for the given PUID.
         """
-        if uid in self.irc.users:
-            nick = self.irc.users[uid].nick
-            log.debug('(%s) Mangling target PUID %s to nick %s', self.irc.name, uid, nick)
+        if uid in self.users:
+            nick = self.users[uid].nick
+            log.debug('(%s) Mangling target PUID %s to nick %s', self.name, uid, nick)
             return nick
         return uid
 
@@ -58,11 +58,11 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         self.sidgen = utils.PUIDGenerator('PSID')
 
         self.has_eob = False
-        ts = self.irc.start_ts
-        f = lambda text: self.irc.send(text, queue=False)
+        ts = self.start_ts
+        f = lambda text: self.send(text, queue=False)
 
         # Enumerate our own server
-        self.irc.sid = self.sidgen.next_sid()
+        self.sid = self.sidgen.next_sid()
 
         # Clear states from last connect
         self.who_received.clear()
@@ -71,7 +71,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         self.ircv3_caps.clear()
         self.ircv3_caps_available.clear()
 
-        sendpass = self.irc.serverdata.get("sendpass")
+        sendpass = self.serverdata.get("sendpass")
         if sendpass:
             f('PASS %s' % sendpass)
 
@@ -81,17 +81,17 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # never replied to).
         def capEnd():
             log.info('(%s) Skipping SASL due to timeout; are the IRCd and services configured '
-                     'properly?', self.irc.name)
+                     'properly?', self.name)
             self.capEnd()
-        self._cap_timer = threading.Timer(self.irc.serverdata.get('sasl_timeout') or 15, capEnd)
+        self._cap_timer = threading.Timer(self.serverdata.get('sasl_timeout') or 15, capEnd)
         self._cap_timer.start()
 
         # This is a really gross hack to get the defined NICK/IDENT/HOST/GECOS.
         # But this connection stuff is done before any of the spawnClient stuff in
         # services_support fires.
-        self.conf_nick = self.irc.serverdata.get('pylink_nick') or conf.conf["bot"].get("nick", "PyLink")
+        self.conf_nick = self.serverdata.get('pylink_nick') or conf.conf["bot"].get("nick", "PyLink")
         f('NICK %s' % (self.conf_nick))
-        ident = self.irc.serverdata.get('pylink_ident') or conf.conf["bot"].get("ident", "pylink")
+        ident = self.serverdata.get('pylink_ident') or conf.conf["bot"].get("ident", "pylink")
         f('USER %s 8 * :%s' % (ident, # TODO: per net realnames or hostnames aren't implemented yet.
                               conf.conf["bot"].get("realname", "PyLink Clientbot")))
 
@@ -103,17 +103,17 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         STUB: Pretends to spawn a new client with a subset of the given options.
         """
 
-        server = server or self.irc.sid
+        server = server or self.sid
         uid = self.uidgen.next_uid(prefix=nick)
 
         ts = ts or int(time.time())
 
-        log.debug('(%s) spawnClient stub called, saving nick %s as PUID %s', self.irc.name, nick, uid)
-        u = self.irc.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        log.debug('(%s) spawnClient stub called, saving nick %s as PUID %s', self.name, nick, uid)
+        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
                                           manipulatable=manipulatable, realhost=realhost, ip=ip)
-        self.irc.servers[server].users.add(uid)
+        self.servers[server].users.add(uid)
 
-        self.irc.applyModes(uid, modes)
+        self.applyModes(uid, modes)
 
         return u
 
@@ -123,85 +123,85 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         """
         name = name.lower()
         sid = self.sidgen.next_sid(prefix=name)
-        self.irc.servers[sid] = IrcServer(uplink, name, internal=internal)
+        self.servers[sid] = IrcServer(uplink, name, internal=internal)
         return sid
 
     def away(self, source, text):
         """STUB: sets away messages for clients internally."""
-        log.debug('(%s) away: target is %s, internal client? %s', self.irc.name, source, self.irc.isInternalClient(source))
+        log.debug('(%s) away: target is %s, internal client? %s', self.name, source, self.isInternalClient(source))
 
-        if self.irc.users[source].away != text:
-            if not self.irc.isInternalClient(source):
-                log.debug('(%s) away: sending AWAY hook from %s with text %r', self.irc.name, source, text)
-                self.irc.callHooks([source, 'AWAY', {'text': text}])
+        if self.users[source].away != text:
+            if not self.isInternalClient(source):
+                log.debug('(%s) away: sending AWAY hook from %s with text %r', self.name, source, text)
+                self.callHooks([source, 'AWAY', {'text': text}])
 
-            self.irc.users[source].away = text
+            self.users[source].away = text
 
     def invite(self, client, target, channel):
         """Invites a user to a channel."""
-        self.irc.send('INVITE %s %s' % (self.irc.getFriendlyName(target), channel))
+        self.send('INVITE %s %s' % (self.getFriendlyName(target), channel))
 
     def join(self, client, channel):
         """STUB: Joins a user to a channel."""
-        channel = self.irc.toLower(channel)
+        channel = self.toLower(channel)
 
         # Only joins for the main PyLink client are actually forwarded. Others are ignored.
         # Note: we do not automatically add our main client to the channel state, as we
         # rely on the /NAMES reply to sync it up properly.
-        if self.irc.pseudoclient and client == self.irc.pseudoclient.uid:
-            self.irc.send('JOIN %s' % channel)
+        if self.pseudoclient and client == self.pseudoclient.uid:
+            self.send('JOIN %s' % channel)
             # Send /names and /who requests right after
-            self.irc.send('MODE %s' % channel)
-            self.irc.send('NAMES %s' % channel)
-            self.irc.send('WHO %s' % channel)
+            self.send('MODE %s' % channel)
+            self.send('NAMES %s' % channel)
+            self.send('WHO %s' % channel)
         else:
-            self.irc.channels[channel].users.add(client)
-            self.irc.users[client].channels.add(channel)
+            self.channels[channel].users.add(client)
+            self.users[client].channels.add(channel)
 
-            log.debug('(%s) join: faking JOIN of client %s/%s to %s', self.irc.name, client,
-                      self.irc.getFriendlyName(client), channel)
-            self.irc.callHooks([client, 'CLIENTBOT_JOIN', {'channel': channel}])
+            log.debug('(%s) join: faking JOIN of client %s/%s to %s', self.name, client,
+                      self.getFriendlyName(client), channel)
+            self.callHooks([client, 'CLIENTBOT_JOIN', {'channel': channel}])
 
     def kick(self, source, channel, target, reason=''):
         """Sends channel kicks."""
 
         log.debug('(%s) kick: checking if target %s (nick: %s) is an internal client? %s',
-                  self.irc.name, target, self.irc.getFriendlyName(target),
-                  self.irc.isInternalClient(target))
-        if self.irc.isInternalClient(target):
+                  self.name, target, self.getFriendlyName(target),
+                  self.isInternalClient(target))
+        if self.isInternalClient(target):
             # Target was one of our virtual clients. Just remove them from the state.
             self.handle_part(target, 'KICK', [channel, reason])
 
             # Send a KICK hook for message formatting.
-            self.irc.callHooks([source, 'CLIENTBOT_KICK', {'channel': channel, 'target': target, 'text': reason}])
+            self.callHooks([source, 'CLIENTBOT_KICK', {'channel': channel, 'target': target, 'text': reason}])
             return
 
-        self.irc.send('KICK %s %s :<%s> %s' % (channel, self._expandPUID(target),
-                      self.irc.getFriendlyName(source), reason))
+        self.send('KICK %s %s :<%s> %s' % (channel, self._expandPUID(target),
+                      self.getFriendlyName(source), reason))
 
         # Don't update our state here: wait for the IRCd to send an acknowledgement instead.
         # There is essentially a 3 second wait to do this, as we send NAMES with a delay
         # to resync any users lost due to kicks being blocked, etc.
         if (channel not in self.kick_queue) or (not self.kick_queue[channel][1].is_alive()):
             # However, only do this if there isn't a NAMES request scheduled already.
-            t = threading.Timer(3, lambda: self.irc.send('NAMES %s' % channel))
-            log.debug('(%s) kick: setting NAMES timer for %s on %s', self.irc.name, target, channel)
+            t = threading.Timer(3, lambda: self.send('NAMES %s' % channel))
+            log.debug('(%s) kick: setting NAMES timer for %s on %s', self.name, target, channel)
 
             # Store the channel, target UID, and timer object in the internal kick queue.
             self.kick_queue[channel] = ({target}, t)
             t.start()
         else:
-            log.debug('(%s) kick: adding %s to kick queue for channel %s', self.irc.name, target, channel)
+            log.debug('(%s) kick: adding %s to kick queue for channel %s', self.name, target, channel)
             self.kick_queue[channel][0].add(target)
 
     def message(self, source, target, text, notice=False):
         """Sends messages to the target."""
         command = 'NOTICE' if notice else 'PRIVMSG'
 
-        if self.irc.pseudoclient and self.irc.pseudoclient.uid == source:
-            self.irc.send('%s %s :%s' % (command, self._expandPUID(target), text))
+        if self.pseudoclient and self.pseudoclient.uid == source:
+            self.send('%s %s :%s' % (command, self._expandPUID(target), text))
         else:
-            self.irc.callHooks([source, 'CLIENTBOT_MESSAGE', {'target': target, 'is_notice': notice, 'text': text}])
+            self.callHooks([source, 'CLIENTBOT_MESSAGE', {'target': target, 'is_notice': notice, 'text': text}])
 
     def mode(self, source, channel, modes, ts=None):
         """Sends channel MODE changes."""
@@ -211,35 +211,35 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # things that were never banned. This prevents the bot from getting caught in a loop
             # with IRCd MODE acknowledgements.
             # FIXME: More related safety checks should be added for this.
-            log.debug('(%s) mode: re-parsing modes %s', self.irc.name, modes)
-            joined_modes = self.irc.joinModes(modes)
-            for modepair in self.irc.parseModes(channel, joined_modes):
-                log.debug('(%s) mode: checking if %s a prefix mode: %s', self.irc.name, modepair, self.irc.prefixmodes)
-                if modepair[0][-1] in self.irc.prefixmodes:
-                    if self.irc.isInternalClient(modepair[1]):
+            log.debug('(%s) mode: re-parsing modes %s', self.name, modes)
+            joined_modes = self.joinModes(modes)
+            for modepair in self.parseModes(channel, joined_modes):
+                log.debug('(%s) mode: checking if %s a prefix mode: %s', self.name, modepair, self.prefixmodes)
+                if modepair[0][-1] in self.prefixmodes:
+                    if self.isInternalClient(modepair[1]):
                         # Ignore prefix modes for virtual internal clients.
-                        log.debug('(%s) mode: skipping virtual client prefixmode change %s', self.irc.name, modepair)
+                        log.debug('(%s) mode: skipping virtual client prefixmode change %s', self.name, modepair)
                         continue
                     else:
                         # For other clients, change the mode argument to nick instead of PUID.
-                        nick = self.irc.getFriendlyName(modepair[1])
-                        log.debug('(%s) mode: coersing mode %s argument to %s', self.irc.name, modepair, nick)
+                        nick = self.getFriendlyName(modepair[1])
+                        log.debug('(%s) mode: coersing mode %s argument to %s', self.name, modepair, nick)
                         modepair = (modepair[0], nick)
                 extmodes.append(modepair)
 
-            log.debug('(%s) mode: filtered modes for %s: %s', self.irc.name, channel, extmodes)
+            log.debug('(%s) mode: filtered modes for %s: %s', self.name, channel, extmodes)
             if extmodes:
-                self.irc.send('MODE %s %s' % (channel, self.irc.joinModes(extmodes)))
+                self.send('MODE %s %s' % (channel, self.joinModes(extmodes)))
                 # Don't update the state here: the IRCd sill respond with a MODE reply if successful.
 
     def nick(self, source, newnick):
         """STUB: Sends NICK changes."""
-        if self.irc.pseudoclient and source == self.irc.pseudoclient.uid:
-            self.irc.send('NICK :%s' % newnick)
+        if self.pseudoclient and source == self.pseudoclient.uid:
+            self.send('NICK :%s' % newnick)
             # No state update here: the IRCd will respond with a NICK acknowledgement if the change succeeds.
         else:
-            self.irc.callHooks([source, 'CLIENTBOT_NICK', {'newnick': newnick}])
-            self.irc.users[source].nick = newnick
+            self.callHooks([source, 'CLIENTBOT_NICK', {'newnick': newnick}])
+            self.users[source].nick = newnick
 
     def notice(self, source, target, text):
         """Sends notices to the target."""
@@ -250,29 +250,29 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         """
         Sends PING to the uplink.
         """
-        if self.irc.uplink:
-            self.irc.send('PING %s' % self.irc.getFriendlyName(self.irc.uplink))
+        if self.uplink:
+            self.send('PING %s' % self.getFriendlyName(self.uplink))
 
             # Poll WHO periodically to figure out any ident/host/away status changes.
-            for channel in self.irc.pseudoclient.channels:
-                self.irc.send('WHO %s' % channel)
+            for channel in self.pseudoclient.channels:
+                self.send('WHO %s' % channel)
 
     def part(self, source, channel, reason=''):
         """STUB: Parts a user from a channel."""
-        self.irc.channels[channel].removeuser(source)
-        self.irc.users[source].channels.discard(channel)
+        self.channels[channel].removeuser(source)
+        self.users[source].channels.discard(channel)
 
         # Only parts for the main PyLink client are actually forwarded. Others are ignored.
-        if self.irc.pseudoclient and source == self.irc.pseudoclient.uid:
-            self.irc.send('PART %s :%s' % (channel, reason))
+        if self.pseudoclient and source == self.pseudoclient.uid:
+            self.send('PART %s :%s' % (channel, reason))
         else:
-            self.irc.callHooks([source, 'CLIENTBOT_PART', {'channel': channel, 'text': reason}])
+            self.callHooks([source, 'CLIENTBOT_PART', {'channel': channel, 'text': reason}])
 
     def quit(self, source, reason):
         """STUB: Quits a client."""
-        userdata = self.irc.users[source]
+        userdata = self.users[source]
         self.removeClient(source)
-        self.irc.callHooks([source, 'CLIENTBOT_QUIT', {'text': reason, 'userdata': userdata}])
+        self.callHooks([source, 'CLIENTBOT_QUIT', {'text': reason, 'userdata': userdata}])
 
     def sjoin(self, server, channel, users, ts=None, modes=set()):
         """STUB: bursts joins from a server."""
@@ -280,16 +280,16 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # given. modes and TS are currently ignored.
         puids = {u[-1] for u in users}
         for user in puids:
-            if self.irc.pseudoclient and self.irc.pseudoclient.uid == user:
+            if self.pseudoclient and self.pseudoclient.uid == user:
                 # If the SJOIN affects our main client, forward it as a regular JOIN.
                 self.join(user, channel)
             else:
                 # Otherwise, track the state for our virtual clients.
-                self.irc.users[user].channels.add(channel)
+                self.users[user].channels.add(channel)
 
-        self.irc.channels[channel].users |= puids
-        nicks = {self.irc.getFriendlyName(u) for u in puids}
-        self.irc.callHooks([server, 'CLIENTBOT_SJOIN', {'channel': channel, 'nicks': nicks}])
+        self.channels[channel].users |= puids
+        nicks = {self.getFriendlyName(u) for u in puids}
+        self.callHooks([server, 'CLIENTBOT_SJOIN', {'channel': channel, 'nicks': nicks}])
 
     def squit(self, source, target, text):
         """STUB: SQUITs a server."""
@@ -298,7 +298,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         squit_data = self._squit(source, 'CLIENTBOT_VIRTUAL_SQUIT', [target, text])
 
         if squit_data.get('nicks'):
-            self.irc.callHooks([source, 'CLIENTBOT_SQUIT', squit_data])
+            self.callHooks([source, 'CLIENTBOT_SQUIT', squit_data])
 
     def _stub(self, *args):
         """Stub outgoing command function (does nothing)."""
@@ -307,28 +307,28 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
 
     def updateClient(self, target, field, text):
         """Updates the known ident, host, or realname of a client."""
-        if target not in self.irc.users:
-            log.warning("(%s) Unknown target %s for updateClient()", self.irc.name, target)
+        if target not in self.users:
+            log.warning("(%s) Unknown target %s for updateClient()", self.name, target)
             return
 
-        u = self.irc.users[target]
+        u = self.users[target]
 
         if field == 'IDENT' and u.ident != text:
             u.ident = text
-            if not self.irc.isInternalClient(target):
+            if not self.isInternalClient(target):
                 # We're updating the host of an external client in our state, so send the appropriate
                 # hook payloads.
-                self.irc.callHooks([self.irc.sid, 'CHGIDENT',
+                self.callHooks([self.sid, 'CHGIDENT',
                                    {'target': target, 'newident': text}])
         elif field == 'HOST' and u.host != text:
             u.host = text
-            if not self.irc.isInternalClient(target):
-                self.irc.callHooks([self.irc.sid, 'CHGHOST',
+            if not self.isInternalClient(target):
+                self.callHooks([self.sid, 'CHGHOST',
                                    {'target': target, 'newhost': text}])
         elif field in ('REALNAME', 'GECOS') and u.realname != text:
             u.realname = text
-            if not self.irc.isInternalClient(target):
-                self.irc.callHooks([self.irc.sid, 'CHGNAME',
+            if not self.isInternalClient(target):
+                self.callHooks([self.sid, 'CHGNAME',
                                    {'target': target, 'newgecos': text}])
         else:
             return  # Nothing changed
@@ -340,19 +340,19 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         Limited (internal) nick collision checking is done here to prevent Clientbot users from
         being confused with virtual clients, and vice versa."""
         self._validateNick(nick)
-        idsource = self.irc.nickToUid(nick)
-        is_internal = self.irc.isInternalClient(idsource)
+        idsource = self.nickToUid(nick)
+        is_internal = self.isInternalClient(idsource)
 
         # If this sender isn't known or it is one of our virtual clients, spawn a new one.
         # This also takes care of any nick collisions caused by new, Clientbot users
         # taking the same nick as one of our virtual clients, and will force the virtual client to lose.
-        if (not idsource) or (is_internal and self.irc.pseudoclient and idsource != self.irc.pseudoclient.uid):
+        if (not idsource) or (is_internal and self.pseudoclient and idsource != self.pseudoclient.uid):
             if idsource:
-                log.debug('(%s) Nick-colliding virtual client %s/%s', self.irc.name, idsource, nick)
-                self.irc.callHooks([self.irc.sid, 'CLIENTBOT_NICKCOLLIDE', {'target': idsource, 'parse_as': 'SAVE'}])
+                log.debug('(%s) Nick-colliding virtual client %s/%s', self.name, idsource, nick)
+                self.callHooks([self.sid, 'CLIENTBOT_NICKCOLLIDE', {'target': idsource, 'parse_as': 'SAVE'}])
 
             idsource = self.spawnClient(nick, ident or 'unknown', host or 'unknown',
-                                        server=self.irc.uplink, realname=FALLBACK_REALNAME).uid
+                                        server=self.uplink, realname=FALLBACK_REALNAME).uid
 
         return idsource
 
@@ -373,7 +373,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                 tagdata[idx] = tag
 
             results = self.parseCapabilities(tagdata, fallback=None)
-            log.debug('(%s) parsed message tags %s', self.irc.name, results)
+            log.debug('(%s) parsed message tags %s', self.name, results)
             return results
         return {}
 
@@ -395,7 +395,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         except IndexError:
             # Raw command without an explicit sender; assume it's being sent by our uplink.
             args = self.parseArgs(data)
-            idsource = sender = self.irc.uplink
+            idsource = sender = self.uplink
             command = args[0]
             args = args[1:]
         else:
@@ -405,7 +405,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             if ('!' not in sender) and '.' in sender:
                 # Sender is a server name. XXX: make this check more foolproof
                 idsource = self._get_SID(sender)
-                if idsource not in self.irc.servers:
+                if idsource not in self.servers:
                     idsource = self.spawnServer(sender, internal=False)
             else:
                 # Sender is a either a nick or a nick!user@host prefix. Split it into its relevant parts.
@@ -430,8 +430,8 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         """
         Abort SASL login by sending CAP END.
         """
-        self.irc.send('CAP END')
-        log.debug("(%s) Stopping CAP END timer.", self.irc.name)
+        self.send('CAP END')
+        log.debug("(%s) Stopping CAP END timer.", self.name)
         self._cap_timer.cancel()
 
     def saslAuth(self):
@@ -440,43 +440,43 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         is enabled and correctly configured, and False otherwise.
         """
         if 'sasl' not in self.ircv3_caps:
-            log.info("(%s) Skipping SASL auth since the IRCd doesn't support it.", self.irc.name)
+            log.info("(%s) Skipping SASL auth since the IRCd doesn't support it.", self.name)
             return
 
-        sasl_mech = self.irc.serverdata.get('sasl_mechanism')
+        sasl_mech = self.serverdata.get('sasl_mechanism')
         if sasl_mech:
             sasl_mech = sasl_mech.upper()
-            sasl_user = self.irc.serverdata.get('sasl_username')
-            sasl_pass = self.irc.serverdata.get('sasl_password')
-            ssl_cert = self.irc.serverdata.get('ssl_certfile')
-            ssl_key = self.irc.serverdata.get('ssl_keyfile')
-            ssl = self.irc.serverdata.get('ssl')
+            sasl_user = self.serverdata.get('sasl_username')
+            sasl_pass = self.serverdata.get('sasl_password')
+            ssl_cert = self.serverdata.get('ssl_certfile')
+            ssl_key = self.serverdata.get('ssl_keyfile')
+            ssl = self.serverdata.get('ssl')
 
             if sasl_mech == 'PLAIN':
                 if not (sasl_user and sasl_pass):
                     log.warning("(%s) Not attempting PLAIN authentication; sasl_username and/or "
-                                "sasl_password aren't correctly set.", self.irc.name)
+                                "sasl_password aren't correctly set.", self.name)
                     return False
             elif sasl_mech == 'EXTERNAL':
                 if not ssl:
                     log.warning("(%s) Not attempting EXTERNAL authentication; SASL external requires "
-                                "SSL, but it isn't enabled.", self.irc.name)
+                                "SSL, but it isn't enabled.", self.name)
                     return False
                 elif not (ssl_cert and ssl_key):
                     log.warning("(%s) Not attempting EXTERNAL authentication; ssl_certfile and/or "
-                                "ssl_keyfile aren't correctly set.", self.irc.name)
+                                "ssl_keyfile aren't correctly set.", self.name)
                     return False
             else:
-                log.warning('(%s) Unsupported SASL mechanism %s; aborting SASL.', self.irc.name, sasl_mech)
+                log.warning('(%s) Unsupported SASL mechanism %s; aborting SASL.', self.name, sasl_mech)
                 return False
-            self.irc.send('AUTHENTICATE %s' % sasl_mech, queue=False)
+            self.send('AUTHENTICATE %s' % sasl_mech, queue=False)
             return True
         return False
 
     def sendAuthChunk(self, data):
         """Send Base64 encoded SASL authentication chunks."""
         enc_data = base64.b64encode(data).decode()
-        self.irc.send('AUTHENTICATE %s' % enc_data, queue=False)
+        self.send('AUTHENTICATE %s' % enc_data, queue=False)
 
     def handle_authenticate(self, source, command, args):
         """
@@ -488,21 +488,21 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         if not args:
             return
         if args[0] == '+':
-            sasl_mech = self.irc.serverdata['sasl_mechanism'].upper()
+            sasl_mech = self.serverdata['sasl_mechanism'].upper()
             if sasl_mech == 'PLAIN':
-                sasl_user = self.irc.serverdata['sasl_username']
-                sasl_pass = self.irc.serverdata['sasl_password']
+                sasl_user = self.serverdata['sasl_username']
+                sasl_pass = self.serverdata['sasl_password']
                 authstring = '%s\0%s\0%s' % (sasl_user, sasl_user, sasl_pass)
                 self.sendAuthChunk(authstring.encode('utf-8'))
             elif sasl_mech == 'EXTERNAL':
-                self.irc.send('AUTHENTICATE +')
+                self.send('AUTHENTICATE +')
 
     def handle_904(self, source, command, args):
         """
         Handles SASL authentication status reports.
         """
         logfunc = log.info if command == '903' else log.warning
-        logfunc('(%s) %s', self.irc.name, args[-1])
+        logfunc('(%s) %s', self.name, args[-1])
         if not self.has_eob:
             self.capEnd()
     handle_903 = handle_902 = handle_905 = handle_906 = handle_907 = handle_904
@@ -513,9 +513,9 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # And by the ones we don't already have.
         caps_wanted = available_caps - self.ircv3_caps
 
-        log.debug('(%s) Requesting IRCv3 capabilities %s (available: %s)', self.irc.name, caps_wanted, available_caps)
+        log.debug('(%s) Requesting IRCv3 capabilities %s (available: %s)', self.name, caps_wanted, available_caps)
         if caps_wanted:
-            self.irc.send('CAP REQ :%s' % ' '.join(caps_wanted), queue=False)
+            self.send('CAP REQ :%s' % ' '.join(caps_wanted), queue=False)
 
     def handle_cap(self, source, command, args):
         """
@@ -527,7 +527,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # Server: CAP * LS * :multi-prefix extended-join account-notify batch invite-notify tls
             # Server: CAP * LS * :cap-notify server-time example.org/dummy-cap=dummyvalue example.org/second-dummy-cap
             # Server: CAP * LS :userhost-in-names sasl=EXTERNAL,DH-AES,DH-BLOWFISH,ECDSA-NIST256P-CHALLENGE,PLAIN
-            log.debug('(%s) Got new capabilities %s', self.irc.name, args[-1])
+            log.debug('(%s) Got new capabilities %s', self.name, args[-1])
             self.ircv3_caps_available.update(self.parseCapabilities(args[-1], None))
             if args[2] != '*':
                 self.requestNewCaps()
@@ -535,7 +535,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         elif subcmd == 'ACK':
             # Server: CAP * ACK :multi-prefix sasl
             newcaps = set(args[-1].split())
-            log.debug('(%s) Received ACK for IRCv3 capabilities %s', self.irc.name, newcaps)
+            log.debug('(%s) Received ACK for IRCv3 capabilities %s', self.name, newcaps)
             self.ircv3_caps |= newcaps
 
             # Only send CAP END immediately if SASL is disabled. Otherwise, wait for the 90x responses
@@ -545,7 +545,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
                     self.capEnd()
         elif subcmd == 'NAK':
             log.warning('(%s) Got NAK for IRCv3 capabilities %s, even though they were supposedly available',
-                        self.irc.name, args[-1])
+                        self.name, args[-1])
             if not self.has_eob:
                 self.capEnd()
         elif subcmd == 'NEW':
@@ -553,19 +553,19 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # :irc.example.com CAP tester NEW :away-notify extended-join
             # Note: CAP NEW allows capabilities with values (e.g. sasl=mech1,mech2), while CAP DEL
             # does not.
-            log.debug('(%s) Got new capabilities %s', self.irc.name, args[-1])
+            log.debug('(%s) Got new capabilities %s', self.name, args[-1])
             newcaps = self.parseCapabilities(args[-1], None)
             self.ircv3_caps_available.update(newcaps)
             self.requestNewCaps()
 
             # Attempt SASL auth routines when sasl is added/removed, if doing so is enabled.
-            if 'sasl' in newcaps and self.irc.serverdata.get('sasl_reauth'):
-                log.debug('(%s) Attempting SASL reauth due to CAP NEW', self.irc.name)
+            if 'sasl' in newcaps and self.serverdata.get('sasl_reauth'):
+                log.debug('(%s) Attempting SASL reauth due to CAP NEW', self.name)
                 self.saslAuth()
 
         elif subcmd == 'DEL':
             # :irc.example.com CAP modernclient DEL :userhost-in-names multi-prefix away-notify
-            log.debug('(%s) Removing capabilities %s', self.irc.name, args[-1])
+            log.debug('(%s) Removing capabilities %s', self.name, args[-1])
             for cap in args[-1].split():
                 # Remove the capabilities from the list available, and return None (ignore) if any fail
                 self.ircv3_caps_available.pop(cap, None)
@@ -576,41 +576,41 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         Handles 001 / RPL_WELCOME.
         """
         # enumerate our uplink
-        self.irc.uplink = source
+        self.uplink = source
 
     def handle_005(self, source, command, args):
         """
         Handles 005 / RPL_ISUPPORT.
         """
         self.caps.update(self.parseCapabilities(args[1:-1]))
-        log.debug('(%s) handle_005: self.caps is %s', self.irc.name, self.caps)
+        log.debug('(%s) handle_005: self.caps is %s', self.name, self.caps)
 
         if 'CHANMODES' in self.caps:
-            self.irc.cmodes['*A'], self.irc.cmodes['*B'], self.irc.cmodes['*C'], self.irc.cmodes['*D'] = \
+            self.cmodes['*A'], self.cmodes['*B'], self.cmodes['*C'], self.cmodes['*D'] = \
                 self.caps['CHANMODES'].split(',')
-        log.debug('(%s) handle_005: cmodes: %s', self.irc.name, self.irc.cmodes)
+        log.debug('(%s) handle_005: cmodes: %s', self.name, self.cmodes)
 
         if 'USERMODES' in self.caps:
-            self.irc.umodes['*A'], self.irc.umodes['*B'], self.irc.umodes['*C'], self.irc.umodes['*D'] = \
+            self.umodes['*A'], self.umodes['*B'], self.umodes['*C'], self.umodes['*D'] = \
                 self.caps['USERMODES'].split(',')
-        log.debug('(%s) handle_005: umodes: %s', self.irc.name, self.irc.umodes)
+        log.debug('(%s) handle_005: umodes: %s', self.name, self.umodes)
 
         self.casemapping = self.caps.get('CASEMAPPING', self.casemapping)
-        log.debug('(%s) handle_005: casemapping set to %s', self.irc.name, self.casemapping)
+        log.debug('(%s) handle_005: casemapping set to %s', self.name, self.casemapping)
 
         if 'PREFIX' in self.caps:
-            self.irc.prefixmodes = prefixmodes = self.parsePrefixes(self.caps['PREFIX'])
-            log.debug('(%s) handle_005: prefix modes set to %s', self.irc.name, self.irc.prefixmodes)
+            self.prefixmodes = prefixmodes = self.parsePrefixes(self.caps['PREFIX'])
+            log.debug('(%s) handle_005: prefix modes set to %s', self.name, self.prefixmodes)
 
             # Autodetect common prefix mode names.
             for char, modename in COMMON_PREFIXMODES:
                 # Don't overwrite existing named mode definitions.
-                if char in self.irc.prefixmodes and modename not in self.irc.cmodes:
-                    self.irc.cmodes[modename] = char
-                    log.debug('(%s) handle_005: autodetecting mode %s (%s) as %s', self.irc.name,
-                              char, self.irc.prefixmodes[char], modename)
+                if char in self.prefixmodes and modename not in self.cmodes:
+                    self.cmodes[modename] = char
+                    log.debug('(%s) handle_005: autodetecting mode %s (%s) as %s', self.name,
+                              char, self.prefixmodes[char], modename)
 
-        self.irc.connected.set()
+        self.connected.set()
 
     def handle_376(self, source, command, args):
         """
@@ -618,8 +618,8 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         """
 
         # Run autoperform commands.
-        for line in self.irc.serverdata.get("autoperform", []):
-            self.irc.send(line)
+        for line in self.serverdata.get("autoperform", []):
+            self.send(line)
 
         # Virtual endburst hook.
         if not self.has_eob:
@@ -634,14 +634,14 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # <- :charybdis.midnight.vpn 353 ice = #test :ice @GL
 
         # Mark "@"-type channels as secret automatically, per RFC2812.
-        channel = self.irc.toLower(args[2])
+        channel = self.toLower(args[2])
         if args[1] == '@':
-            self.irc.applyModes(channel, [('+s', None)])
+            self.applyModes(channel, [('+s', None)])
 
         names = set()
         modes = set()
-        prefix_to_mode = {v:k for k, v in self.irc.prefixmodes.items()}
-        prefixes = ''.join(self.irc.prefixmodes.values())
+        prefix_to_mode = {v:k for k, v in self.prefixmodes.items()}
+        prefixes = ''.join(self.prefixmodes.values())
 
         for name in args[-1].split():
             nick = name.lstrip(prefixes)
@@ -653,41 +653,41 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
 
             # Queue these virtual users to be joined if they're not already in the channel,
             # or we're waiting for a kick acknowledgment for them.
-            if (idsource not in self.irc.channels[channel].users) or (idsource in \
+            if (idsource not in self.channels[channel].users) or (idsource in \
                     self.kick_queue.get(channel, ([],))[0]):
                 names.add(idsource)
-            self.irc.users[idsource].channels.add(channel)
+            self.users[idsource].channels.add(channel)
 
             # Process prefix modes
             for char in name:
-                if char in self.irc.prefixmodes.values():
+                if char in self.prefixmodes.values():
                     modes.add(('+' + prefix_to_mode[char], idsource))
                 else:
                     break
 
         # Statekeeping: make sure the channel's user list is updated!
-        self.irc.channels[channel].users |= names
-        self.irc.applyModes(channel, modes)
+        self.channels[channel].users |= names
+        self.applyModes(channel, modes)
 
-        log.debug('(%s) handle_353: adding users %s to %s', self.irc.name, names, channel)
-        log.debug('(%s) handle_353: adding modes %s to %s', self.irc.name, modes, channel)
+        log.debug('(%s) handle_353: adding users %s to %s', self.name, names, channel)
+        log.debug('(%s) handle_353: adding modes %s to %s', self.name, modes, channel)
 
         # Unless /WHO has already been received for the given channel, we generally send the hook
         # for JOIN after /who data is received, to enumerate the ident, host, and real names of
         # users.
-        if names and hasattr(self.irc.channels[channel], 'who_received'):
+        if names and hasattr(self.channels[channel], 'who_received'):
             # /WHO *HAS* already been received. Send JOIN hooks here because we use this to keep
             # track of any failed KICK attempts sent by the relay bot.
             log.debug('(%s) handle_353: sending JOIN hook because /WHO was already received for %s',
-                      self.irc.name, channel)
-            return {'channel': channel, 'users': names, 'modes': self.irc.channels[channel].modes,
+                      self.name, channel)
+            return {'channel': channel, 'users': names, 'modes': self.channels[channel].modes,
                     'parse_as': "JOIN"}
 
     def _validateNick(self, nick):
         """
         Checks to make sure a nick doesn't clash with a PUID.
         """
-        if nick in self.irc.users or nick in self.irc.servers:
+        if nick in self.users or nick in self.servers:
             raise ProtocolError("Got bad nick %s from IRC which clashes with a PUID. Is someone trying to spoof users?" % nick)
 
     def handle_352(self, source, command, args):
@@ -705,10 +705,10 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         realname = args[-1].split(' ', 1)[-1]
 
         self._validateNick(nick)
-        uid = self.irc.nickToUid(nick)
+        uid = self.nickToUid(nick)
 
         if uid is None:
-            log.debug("(%s) Ignoring extraneous /WHO info for %s", self.irc.name, nick)
+            log.debug("(%s) Ignoring extraneous /WHO info for %s", self.name, nick)
             return
 
         self.updateClient(uid, 'IDENT', ident)
@@ -720,27 +720,27 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # G means away is set (we'll have to fake a message because it's not given)
         # * means IRCop.
         # The rest are prefix modes. Multiple can be given by the IRCd if multiple are set
-        log.debug('(%s) handle_352: status string on user %s: %s', self.irc.name, nick, status)
+        log.debug('(%s) handle_352: status string on user %s: %s', self.name, nick, status)
         if status[0] == 'G':
-            log.debug('(%s) handle_352: calling away() with argument', self.irc.name)
+            log.debug('(%s) handle_352: calling away() with argument', self.name)
             self.away(uid, 'Away')
         elif status[0] == 'H':
-            log.debug('(%s) handle_352: calling away() without argument', self.irc.name)
+            log.debug('(%s) handle_352: calling away() without argument', self.name)
             self.away(uid, '')  # Unmark away status
         else:
-            log.warning('(%s) handle_352: got wrong string %s for away status', self.irc.name, status[0])
+            log.warning('(%s) handle_352: got wrong string %s for away status', self.name, status[0])
 
-        if self.irc.serverdata.get('track_oper_statuses'):
+        if self.serverdata.get('track_oper_statuses'):
             if '*' in status:  # Track IRCop status
-                if not self.irc.isOper(uid, allowAuthed=False):
+                if not self.isOper(uid, allowAuthed=False):
                     # Don't send duplicate oper ups if the target is already oper.
-                    self.irc.applyModes(uid, [('+o', None)])
-                    self.irc.callHooks([uid, 'MODE', {'target': uid, 'modes': {('+o', None)}}])
-                    self.irc.callHooks([uid, 'CLIENT_OPERED', {'text': 'IRC Operator'}])
-            elif self.irc.isOper(uid, allowAuthed=False) and not self.irc.isInternalClient(uid):
+                    self.applyModes(uid, [('+o', None)])
+                    self.callHooks([uid, 'MODE', {'target': uid, 'modes': {('+o', None)}}])
+                    self.callHooks([uid, 'CLIENT_OPERED', {'text': 'IRC Operator'}])
+            elif self.isOper(uid, allowAuthed=False) and not self.isInternalClient(uid):
                 # Track deopers
-                self.irc.applyModes(uid, [('-o', None)])
-                self.irc.callHooks([uid, 'MODE', {'target': uid, 'modes': {('-o', None)}}])
+                self.applyModes(uid, [('-o', None)])
+                self.callHooks([uid, 'MODE', {'target': uid, 'modes': {('-o', None)}}])
 
         self.who_received.add(uid)
 
@@ -753,8 +753,8 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         users = self.who_received.copy()
         self.who_received.clear()
 
-        channel = self.irc.toLower(args[1])
-        c = self.irc.channels[channel]
+        channel = self.toLower(args[1])
+        c = self.channels[channel]
         c.who_received = True
 
         modes = set(c.modes)
@@ -762,13 +762,13 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             # Fill in prefix modes of everyone when doing mock SJOIN.
             try:
                 for mode in c.getPrefixModes(user):
-                    modechar = self.irc.cmodes.get(mode)
-                    log.debug('(%s) handle_315: adding mode %s +%s %s', self.irc.name, mode, modechar, user)
+                    modechar = self.cmodes.get(mode)
+                    log.debug('(%s) handle_315: adding mode %s +%s %s', self.name, mode, modechar, user)
                     if modechar:
                         modes.add((modechar, user))
             except KeyError as e:
                 log.debug("(%s) Ignoring KeyError (%s) from WHO response; it's probably someone we "
-                          "don't share any channels with", self.irc.name, e)
+                          "don't share any channels with", self.name, e)
 
         return {'channel': channel, 'users': users, 'modes': modes,
                 'parse_as': "JOIN"}
@@ -779,8 +779,8 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # irc.pseudoclient doesn't exist as an attribute until we get run the ENDBURST stuff
         # in service_support (this is mapped to 005 here).
         self.conf_nick += '_'
-        self.irc.serverdata['pylink_nick'] = self.conf_nick
-        self.irc.send('NICK %s' % self.conf_nick)
+        self.serverdata['pylink_nick'] = self.conf_nick
+        self.send('NICK %s' % self.conf_nick)
     handle_432 = handle_437 = handle_433
 
     def handle_join(self, source, command, args):
@@ -788,18 +788,18 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         Handles incoming JOINs.
         """
         # <- :GL|!~GL@127.0.0.1 JOIN #whatever
-        channel = self.irc.toLower(args[0])
+        channel = self.toLower(args[0])
         self.join(source, channel)
 
-        return {'channel': channel, 'users': [source], 'modes': self.irc.channels[channel].modes}
+        return {'channel': channel, 'users': [source], 'modes': self.channels[channel].modes}
 
     def handle_kick(self, source, command, args):
         """
         Handles incoming KICKs.
         """
         # <- :GL!~gl@127.0.0.1 KICK #whatever GL| :xd
-        channel = self.irc.toLower(args[0])
-        target = self.irc.nickToUid(args[1])
+        channel = self.toLower(args[0])
+        target = self.nickToUid(args[1])
 
         try:
             reason = args[2]
@@ -808,29 +808,29 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
 
         if channel in self.kick_queue:
             # Remove this client from the kick queue if present there.
-            log.debug('(%s) kick: removing %s from kick queue for channel %s', self.irc.name, target, channel)
+            log.debug('(%s) kick: removing %s from kick queue for channel %s', self.name, target, channel)
             self.kick_queue[channel][0].discard(target)
 
             if not self.kick_queue[channel][0]:
-                log.debug('(%s) kick: cancelling kick timer for channel %s (all kicks accounted for)', self.irc.name, channel)
+                log.debug('(%s) kick: cancelling kick timer for channel %s (all kicks accounted for)', self.name, channel)
                 # There aren't any kicks that failed to be acknowledged. We can remove the timer now
                 self.kick_queue[channel][1].cancel()
                 del self.kick_queue[channel]
 
         # Statekeeping: remove the target from the channel they were previously in.
-        self.irc.channels[channel].removeuser(target)
+        self.channels[channel].removeuser(target)
         try:
-            self.irc.users[target].channels.remove(channel)
+            self.users[target].channels.remove(channel)
         except KeyError:
             pass
 
-        if (not self.irc.isInternalClient(source)) and not self.irc.isInternalServer(source):
+        if (not self.isInternalClient(source)) and not self.isInternalServer(source):
             # Don't repeat hooks if we're the kicker.
-            self.irc.callHooks([source, 'KICK', {'channel': channel, 'target': target, 'text': reason}])
+            self.callHooks([source, 'KICK', {'channel': channel, 'target': target, 'text': reason}])
 
         # Delete channels that we were kicked from, for better state keeping.
-        if self.irc.pseudoclient and target == self.irc.pseudoclient.uid:
-            del self.irc.channels[channel]
+        if self.pseudoclient and target == self.pseudoclient.uid:
+            del self.channels[channel]
 
     def handle_mode(self, source, command, args):
         """Handles MODE changes."""
@@ -838,23 +838,23 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # <- :ice MODE ice :+Zi
         target = args[0]
         if utils.isChannel(target):
-            target = self.irc.toLower(target)
-            oldobj = self.irc.channels[target].deepcopy()
+            target = self.toLower(target)
+            oldobj = self.channels[target].deepcopy()
         else:
-            target = self.irc.nickToUid(target)
+            target = self.nickToUid(target)
             oldobj = None
         modes = args[1:]
-        changedmodes = self.irc.parseModes(target, modes)
-        self.irc.applyModes(target, changedmodes)
+        changedmodes = self.parseModes(target, modes)
+        self.applyModes(target, changedmodes)
 
-        if self.irc.isInternalClient(target):
-            log.debug('(%s) Suppressing MODE change hook for internal client %s', self.irc.name, target)
+        if self.isInternalClient(target):
+            log.debug('(%s) Suppressing MODE change hook for internal client %s', self.name, target)
             return
         if changedmodes:
             # Prevent infinite loops: don't send MODE hooks if the sender is US.
             # Note: this is not the only check in Clientbot to prevent mode loops: if our nick
             # somehow gets desynced, this may not catch everything it's supposed to.
-            if (self.irc.pseudoclient and source != self.irc.pseudoclient.uid) or not self.irc.pseudoclient:
+            if (self.pseudoclient and source != self.pseudoclient.uid) or not self.pseudoclient:
                 return {'target': target, 'modes': changedmodes, 'channeldata': oldobj}
 
     def handle_324(self, source, command, args):
@@ -862,36 +862,36 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # -> MODE #test
         # <- :midnight.vpn 324 GL #test +nt
         # <- :midnight.vpn 329 GL #test 1491773459
-        channel = self.irc.toLower(args[1])
+        channel = self.toLower(args[1])
         modes = args[2:]
-        log.debug('(%s) Got RPL_CHANNELMODEIS (324) modes %s for %s', self.irc.name, modes, channel)
-        changedmodes = self.irc.parseModes(channel, modes)
-        self.irc.applyModes(channel, changedmodes)
+        log.debug('(%s) Got RPL_CHANNELMODEIS (324) modes %s for %s', self.name, modes, channel)
+        changedmodes = self.parseModes(channel, modes)
+        self.applyModes(channel, changedmodes)
 
     def handle_329(self, source, command, args):
         """Handles TS announcements via RPL_CREATIONTIME."""
-        channel = self.irc.toLower(args[1])
+        channel = self.toLower(args[1])
         ts = int(args[2])
-        self.irc.channels[channel].ts = ts
+        self.channels[channel].ts = ts
 
     def handle_nick(self, source, command, args):
         """Handles NICK changes."""
         # <- :GL|!~GL@127.0.0.1 NICK :GL_
 
-        if not self.irc.pseudoclient:
+        if not self.pseudoclient:
             # We haven't properly logged on yet, so any initial NICK should be treated as a forced
             # nick change for US. For example, this clause is used to handle forced nick changes
             # sent by ZNC, when the login nick and the actual IRC nick of the bouncer differ.
 
             # HACK: change the nick config entry so services_support knows what our main
             # pseudoclient is called.
-            oldnick = self.irc.serverdata['pylink_nick']
-            self.irc.serverdata['pylink_nick'] = self.conf_nick = args[0]
-            log.debug('(%s) Pre-auth FNC: Forcing configured nick to %s from %s', self.irc.name, args[0], oldnick)
+            oldnick = self.serverdata['pylink_nick']
+            self.serverdata['pylink_nick'] = self.conf_nick = args[0]
+            log.debug('(%s) Pre-auth FNC: Forcing configured nick to %s from %s', self.name, args[0], oldnick)
             return
 
-        oldnick = self.irc.users[source].nick
-        self.irc.users[source].nick = args[0]
+        oldnick = self.users[source].nick
+        self.users[source].nick = args[0]
 
         return {'newnick': args[0], 'oldnick': oldnick}
 
@@ -900,35 +900,35 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         Handles incoming PARTs.
         """
         # <- :GL|!~GL@127.0.0.1 PART #whatever
-        channels = list(map(self.irc.toLower, args[0].split(',')))
+        channels = list(map(self.toLower, args[0].split(',')))
         try:
             reason = args[1]
         except IndexError:
             reason = ''
 
         for channel in channels:
-            self.irc.channels[channel].removeuser(source)
-        self.irc.users[source].channels -= set(channels)
+            self.channels[channel].removeuser(source)
+        self.users[source].channels -= set(channels)
 
-        self.irc.callHooks([source, 'PART', {'channels': channels, 'text': reason}])
+        self.callHooks([source, 'PART', {'channels': channels, 'text': reason}])
 
         # Clear channels that are empty, or that we're parting.
         for channel in channels:
-            if (self.irc.pseudoclient and source == self.irc.pseudoclient.uid) or not self.irc.channels[channel].users:
-                del self.irc.channels[channel]
+            if (self.pseudoclient and source == self.pseudoclient.uid) or not self.channels[channel].users:
+                del self.channels[channel]
 
     def handle_ping(self, source, command, args):
         """
         Handles incoming PING requests.
         """
-        self.irc.send('PONG :%s' % args[0], queue=False)
+        self.send('PONG :%s' % args[0], queue=False)
 
     def handle_pong(self, source, command, args):
         """
         Handles incoming PONG.
         """
-        if source == self.irc.uplink:
-            self.irc.lastping = time.time()
+        if source == self.uplink:
+            self.lastping = time.time()
 
     def handle_privmsg(self, source, command, args):
         """Handles incoming PRIVMSG/NOTICE."""
@@ -936,22 +936,22 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
         # <- :sender NOTICE somenick :afasfsa
         target = args[0]
 
-        if self.irc.isInternalClient(source) or self.irc.isInternalServer(source):
-            log.warning('(%s) Received %s to %s being routed the wrong way!', self.irc.name, command, target)
+        if self.isInternalClient(source) or self.isInternalServer(source):
+            log.warning('(%s) Received %s to %s being routed the wrong way!', self.name, command, target)
             return
 
         # We use lowercase channels internally.
         if utils.isChannel(target):
-            target = self.irc.toLower(target)
+            target = self.toLower(target)
         else:
-            target = self.irc.nickToUid(target)
+            target = self.nickToUid(target)
         if target:
             return {'target': target, 'text': args[1]}
     handle_notice = handle_privmsg
 
     def handle_quit(self, source, command, args):
         """Handles incoming QUITs."""
-        if self.irc.pseudoclient and source == self.irc.pseudoclient.uid:
+        if self.pseudoclient and source == self.pseudoclient.uid:
             # Someone faked a quit from us? We should abort.
             raise ProtocolError("Received QUIT from uplink (%s)" % args[0])
 

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -11,8 +11,8 @@ COMMON_PREFIXMODES = [('h', 'halfop'), ('a', 'admin'), ('q', 'owner'), ('y', 'ow
 IRCV3_CAPABILITIES = {'multi-prefix', 'sasl'}
 
 class ClientbotWrapperProtocol(IRCCommonProtocol):
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.protocol_caps = {'clear-channels-on-leave', 'slash-in-nicks', 'slash-in-hosts', 'underscore-in-hosts'}
 
@@ -51,7 +51,7 @@ class ClientbotWrapperProtocol(IRCCommonProtocol):
             return nick
         return uid
 
-    def connect(self):
+    def post_connect(self):
         """Initializes a connection to a server."""
         # (Re)initialize counter-based pseudo UID generators
         self.uidgen = utils.PUIDGenerator('PUID')

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -105,7 +105,7 @@ class HybridProtocol(TS6Protocol):
         realname = realname or conf.conf['bot']['realname']
         realhost = realhost or host
         raw_modes = self.join_modes(modes)
-        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        u = self.users[uid] = User(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable)
         self.apply_modes(uid, modes)
         self.servers[server].users.add(uid)
@@ -177,7 +177,7 @@ class HybridProtocol(TS6Protocol):
                   'host=%s realname=%s ip=%s', self.name, nick, ts, uid,
                   ident, host, realname, ip)
 
-        self.users[uid] = IrcUser(nick, ts, uid, numeric, ident, host, realname, host, ip)
+        self.users[uid] = User(nick, ts, uid, numeric, ident, host, realname, host, ip)
 
         parsedmodes = self.parse_modes(uid, [modes])
         log.debug('(%s) handle_uid: Applying modes %s for %s', self.name, parsedmodes, uid)

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -68,7 +68,7 @@ class HybridProtocol(TS6Protocol):
         # CHW: Allow sending messages to @#channel and the like.
         # KNOCK: Support for /knock
         # SVS: Deal with extended NICK/UID messages that contain service IDs/stamps
-        # TBURST: Topic Burst command; we send this in topicBurst
+        # TBURST: Topic Burst command; we send this in topic_burst
         # DLN: DLINE command
         # UNDLN: UNDLINE command
         # KLN: KLINE command
@@ -135,7 +135,7 @@ class HybridProtocol(TS6Protocol):
         else:
             raise NotImplementedError("Changing field %r of a client is unsupported by this protocol." % field)
 
-    def topicBurst(self, numeric, target, text):
+    def topic_burst(self, numeric, target, text):
         """Sends a topic change from a PyLink server. This is usually used on burst."""
         # <- :0UY TBURST 1459308205 #testchan 1459309379 dan!~d@localhost :sdf
         if not self.is_internal_server(numeric):

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -5,10 +5,10 @@ from pylinkirc.log import log
 from pylinkirc.classes import *
 from pylinkirc.protocols.ts6 import *
 
+# This protocol module inherits from the TS6 protocol.
 class HybridProtocol(TS6Protocol):
-    def __init__(self, irc):
-        # This protocol module inherits from the TS6 protocol.
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.casemapping = 'ascii'
         self.caps = {}
@@ -16,7 +16,7 @@ class HybridProtocol(TS6Protocol):
         self.has_eob = False
         self.protocol_caps -= {'slash-in-hosts'}
 
-    def connect(self):
+    def post_connect(self):
         """Initializes a connection to a server."""
         ts = self.irc.start_ts
         self.has_eob = False

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -18,9 +18,9 @@ class HybridProtocol(TS6Protocol):
 
     def post_connect(self):
         """Initializes a connection to a server."""
-        ts = self.irc.start_ts
+        ts = self.start_ts
         self.has_eob = False
-        f = self.irc.send
+        f = self.send
 
         # https://github.com/grawity/irc-docs/blob/master/server/ts6.txt#L80
         cmodes = {
@@ -37,7 +37,7 @@ class HybridProtocol(TS6Protocol):
             '*A': 'beI', '*B': 'k', '*C': 'l', '*D': 'cimnprstCMORS'
         }
 
-        self.irc.cmodes = cmodes
+        self.cmodes = cmodes
 
         umodes = {
             'oper': 'o', 'invisible': 'i', 'wallops': 'w', 'locops': 'l',
@@ -52,13 +52,13 @@ class HybridProtocol(TS6Protocol):
             '*A': '', '*B': '', '*C': '', '*D': 'DFGHRSWabcdefgijklnopqrsuwxy'
         }
 
-        self.irc.umodes = umodes
+        self.umodes = umodes
 
         # halfops is mandatory on Hybrid
-        self.irc.prefixmodes = {'o': '@', 'h': '%', 'v': '+'}
+        self.prefixmodes = {'o': '@', 'h': '%', 'v': '+'}
 
         # https://github.com/grawity/irc-docs/blob/master/server/ts6.txt#L55
-        f('PASS %s TS 6 %s' % (self.irc.serverdata["sendpass"], self.irc.sid))
+        f('PASS %s TS 6 %s' % (self.serverdata["sendpass"], self.sid))
 
         # We request the following capabilities (for hybrid):
 
@@ -79,11 +79,11 @@ class HybridProtocol(TS6Protocol):
         # EOB: Supports EOB (end of burst) command
         f('CAPAB :TBURST DLN KNOCK UNDLN UNKLN KLN ENCAP IE EX HOPS CHW SVS CLUSTER EOB QS')
 
-        f('SERVER %s 0 :%s' % (self.irc.serverdata["hostname"],
-                               self.irc.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']))
+        f('SERVER %s 0 :%s' % (self.serverdata["hostname"],
+                               self.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']))
 
         # send endburst now
-        self.irc.send(':%s EOB' % (self.irc.sid,))
+        self.send(':%s EOB' % (self.sid,))
 
     def spawnClient(self, nick, ident='null', host='null', realhost=None, modes=set(),
             server=None, ip='0.0.0.0', realname=None, ts=None, opertype=None,
@@ -95,8 +95,8 @@ class HybridProtocol(TS6Protocol):
         up to plugins to make sure they don't introduce anything invalid.
         """
 
-        server = server or self.irc.sid
-        if not self.irc.isInternalServer(server):
+        server = server or self.sid
+        if not self.isInternalServer(server):
             raise ValueError('Server %r is not a PyLink server!' % server)
 
         uid = self.uidgen[server].next_uid()
@@ -104,11 +104,11 @@ class HybridProtocol(TS6Protocol):
         ts = ts or int(time.time())
         realname = realname or conf.conf['bot']['realname']
         realhost = realhost or host
-        raw_modes = self.irc.joinModes(modes)
-        u = self.irc.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        raw_modes = self.joinModes(modes)
+        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable)
-        self.irc.applyModes(uid, modes)
-        self.irc.servers[server].users.add(uid)
+        self.applyModes(uid, modes)
+        self.servers[server].users.add(uid)
         self._send_with_prefix(server, "UID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "
                 "* :{realname}".format(ts=ts, host=host,
                 nick=nick, ident=ident, uid=uid,
@@ -125,28 +125,28 @@ class HybridProtocol(TS6Protocol):
         # parv[4] = optional argument (services account, vhost)
         field = field.upper()
 
-        ts = self.irc.users[target].ts
+        ts = self.users[target].ts
 
         if field == 'HOST':
-            self.irc.users[target].host = text
+            self.users[target].host = text
             # On Hybrid, it appears that host changing is actually just forcing umode
             # "+x <hostname>" on the target. -GLolol
-            self._send_with_prefix(self.irc.sid, 'SVSMODE %s %s +x %s' % (target, ts, text))
+            self._send_with_prefix(self.sid, 'SVSMODE %s %s +x %s' % (target, ts, text))
         else:
             raise NotImplementedError("Changing field %r of a client is unsupported by this protocol." % field)
 
     def topicBurst(self, numeric, target, text):
         """Sends a topic change from a PyLink server. This is usually used on burst."""
         # <- :0UY TBURST 1459308205 #testchan 1459309379 dan!~d@localhost :sdf
-        if not self.irc.isInternalServer(numeric):
+        if not self.isInternalServer(numeric):
             raise LookupError('No such PyLink server exists.')
 
-        ts = self.irc.channels[target].ts
-        servername = self.irc.servers[numeric].name
+        ts = self.channels[target].ts
+        servername = self.servers[numeric].name
 
         self._send_with_prefix(numeric, 'TBURST %s %s %s %s :%s' % (ts, target, int(time.time()), servername, text))
-        self.irc.channels[target].topic = text
-        self.irc.channels[target].topicset = True
+        self.channels[target].topic = text
+        self.channels[target].topicset = True
 
     # command handlers
 
@@ -154,13 +154,13 @@ class HybridProtocol(TS6Protocol):
         # We only get a list of keywords here. Hybrid obviously assumes that
         # we know what modes it supports (indeed, this is a standard list).
         # <- CAPAB :UNDLN UNKLN KLN TBURST KNOCK ENCAP DLN IE EX HOPS CHW SVS CLUSTER EOB QS
-        self.irc.caps = caps = args[0].split()
+        self.caps = caps = args[0].split()
         for required_cap in ('EX', 'IE', 'SVS', 'EOB', 'HOPS', 'QS', 'TBURST', 'SVS'):
              if required_cap not in caps:
                  raise ProtocolError('%s not found in TS6 capabilities list; this is required! (got %r)' % (required_cap, caps))
 
-        log.debug('(%s) self.irc.connected set!', self.irc.name)
-        self.irc.connected.set()
+        log.debug('(%s) self.connected set!', self.name)
+        self.connected.set()
 
     def handle_uid(self, numeric, command, args):
         """
@@ -174,39 +174,39 @@ class HybridProtocol(TS6Protocol):
         if account == '*':
             account = None
         log.debug('(%s) handle_uid: got args nick=%s ts=%s uid=%s ident=%s '
-                  'host=%s realname=%s ip=%s', self.irc.name, nick, ts, uid,
+                  'host=%s realname=%s ip=%s', self.name, nick, ts, uid,
                   ident, host, realname, ip)
 
-        self.irc.users[uid] = IrcUser(nick, ts, uid, numeric, ident, host, realname, host, ip)
+        self.users[uid] = IrcUser(nick, ts, uid, numeric, ident, host, realname, host, ip)
 
-        parsedmodes = self.irc.parseModes(uid, [modes])
-        log.debug('(%s) handle_uid: Applying modes %s for %s', self.irc.name, parsedmodes, uid)
-        self.irc.applyModes(uid, parsedmodes)
-        self.irc.servers[numeric].users.add(uid)
+        parsedmodes = self.parseModes(uid, [modes])
+        log.debug('(%s) handle_uid: Applying modes %s for %s', self.name, parsedmodes, uid)
+        self.applyModes(uid, parsedmodes)
+        self.servers[numeric].users.add(uid)
 
         # Call the OPERED UP hook if +o is being added to the mode list.
         if ('+o', None) in parsedmodes:
-            self.irc.callHooks([uid, 'CLIENT_OPERED', {'text': 'IRC_Operator'}])
+            self.callHooks([uid, 'CLIENT_OPERED', {'text': 'IRC_Operator'}])
 
         # Set the account name if present
         if account:
-            self.irc.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': account}])
+            self.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': account}])
 
         return {'uid': uid, 'ts': ts, 'nick': nick, 'realname': realname, 'host': host, 'ident': ident, 'ip': ip}
 
     def handle_tburst(self, numeric, command, args):
         """Handles incoming topic burst (TBURST) commands."""
         # <- :0UY TBURST 1459308205 #testchan 1459309379 dan!~d@localhost :sdf
-        channel = self.irc.toLower(args[1])
+        channel = self.toLower(args[1])
         ts = args[2]
         setter = args[3]
         topic = args[-1]
-        self.irc.channels[channel].topic = topic
-        self.irc.channels[channel].topicset = True
+        self.channels[channel].topic = topic
+        self.channels[channel].topicset = True
         return {'channel': channel, 'setter': setter, 'ts': ts, 'text': topic}
 
     def handle_eob(self, numeric, command, args):
-        log.debug('(%s) end of burst received', self.irc.name)
+        log.debug('(%s) end of burst received', self.name)
         if not self.has_eob:  # Only call ENDBURST hooks if we haven't already.
             return {}
 
@@ -221,7 +221,7 @@ class HybridProtocol(TS6Protocol):
         target = args[0]
         ts = args[1]
         modes = args[2:]
-        parsedmodes = self.irc.parseModes(target, modes)
+        parsedmodes = self.parseModes(target, modes)
 
         for modepair in parsedmodes:
             if modepair[0] == '+d':
@@ -241,7 +241,7 @@ class HybridProtocol(TS6Protocol):
 
                 # Send the login hook, and remove this mode from the mode
                 # list, as it shouldn't be parsed literally.
-                self.irc.callHooks([target, 'CLIENT_SERVICES_LOGIN', {'text': account}])
+                self.callHooks([target, 'CLIENT_SERVICES_LOGIN', {'text': account}])
                 parsedmodes.remove(modepair)
 
             elif modepair[0] == '+x':
@@ -250,16 +250,16 @@ class HybridProtocol(TS6Protocol):
                 # to some.host, for example.
                 host = args[-1]
 
-                self.irc.users[target].host = host
+                self.users[target].host = host
 
                 # Propagate the hostmask change as a hook.
-                self.irc.callHooks([numeric, 'CHGHOST',
+                self.callHooks([numeric, 'CHGHOST',
                                    {'target': target, 'newhost': host}])
 
                 parsedmodes.remove(modepair)
 
         if parsedmodes:
-            self.irc.applyModes(target, parsedmodes)
+            self.applyModes(target, parsedmodes)
 
         return {'target': target, 'modes': parsedmodes}
 

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -85,7 +85,7 @@ class HybridProtocol(TS6Protocol):
         # send endburst now
         self.send(':%s EOB' % (self.sid,))
 
-    def spawnClient(self, nick, ident='null', host='null', realhost=None, modes=set(),
+    def spawn_client(self, nick, ident='null', host='null', realhost=None, modes=set(),
             server=None, ip='0.0.0.0', realname=None, ts=None, opertype=None,
             manipulatable=False):
         """

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -115,7 +115,7 @@ class HybridProtocol(TS6Protocol):
                 modes=raw_modes, ip=ip, realname=realname))
         return u
 
-    def updateClient(self, target, field, text):
+    def update_client(self, target, field, text):
         """Updates the ident, host, or realname of a PyLink client."""
         # https://github.com/ircd-hybrid/ircd-hybrid/blob/58323b8/modules/m_svsmode.c#L40-L103
         # parv[0] = command

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -109,7 +109,7 @@ class HybridProtocol(TS6Protocol):
             realhost=realhost, ip=ip, manipulatable=manipulatable)
         self.irc.applyModes(uid, modes)
         self.irc.servers[server].users.add(uid)
-        self._send(server, "UID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "
+        self._send_with_prefix(server, "UID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "
                 "* :{realname}".format(ts=ts, host=host,
                 nick=nick, ident=ident, uid=uid,
                 modes=raw_modes, ip=ip, realname=realname))
@@ -131,7 +131,7 @@ class HybridProtocol(TS6Protocol):
             self.irc.users[target].host = text
             # On Hybrid, it appears that host changing is actually just forcing umode
             # "+x <hostname>" on the target. -GLolol
-            self._send(self.irc.sid, 'SVSMODE %s %s +x %s' % (target, ts, text))
+            self._send_with_prefix(self.irc.sid, 'SVSMODE %s %s +x %s' % (target, ts, text))
         else:
             raise NotImplementedError("Changing field %r of a client is unsupported by this protocol." % field)
 
@@ -144,7 +144,7 @@ class HybridProtocol(TS6Protocol):
         ts = self.irc.channels[target].ts
         servername = self.irc.servers[numeric].name
 
-        self._send(numeric, 'TBURST %s %s %s %s :%s' % (ts, target, int(time.time()), servername, text))
+        self._send_with_prefix(numeric, 'TBURST %s %s %s %s :%s' % (ts, target, int(time.time()), servername, text))
         self.irc.channels[target].topic = text
         self.irc.channels[target].topicset = True
 

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -33,7 +33,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
     ### Outgoing commands
 
-    def spawnClient(self, nick, ident='null', host='null', realhost=None, modes=set(),
+    def spawn_client(self, nick, ident='null', host='null', realhost=None, modes=set(),
             server=None, ip='0.0.0.0', realname=None, ts=None, opertype='IRC Operator',
             manipulatable=False):
         """

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -255,7 +255,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
             raise LookupError('No such PyLink client exists.')
         self._send_with_prefix(numeric, 'ENCAP * KNOCK %s :%s' % (target, text))
 
-    def updateClient(self, target, field, text):
+    def update_client(self, target, field, text):
         """Updates the ident, host, or realname of any connected client."""
         field = field.upper()
 

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -53,7 +53,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         realname = realname or conf.conf['bot']['realname']
         realhost = realhost or host
         raw_modes = self.join_modes(modes)
-        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        u = self.users[uid] = User(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable, opertype=opertype)
 
         self.apply_modes(uid, modes)
@@ -163,7 +163,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         recognize ANY non-burst oper ups.
 
         Plugins don't have to call this function themselves, but they can
-        set the opertype attribute of an IrcUser object (in self.users),
+        set the opertype attribute of an User object (in self.users),
         and the change will be reflected here."""
         userobj = self.users[target]
         try:
@@ -577,7 +577,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         uid, ts, nick, realhost, host, ident, ip = args[0:7]
         self.check_nick_collision(nick)
         realname = args[-1]
-        self.users[uid] = userobj = IrcUser(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
+        self.users[uid] = userobj = User(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
 
         parsedmodes = self.parse_modes(uid, [args[8], args[9]])
         self.apply_modes(uid, parsedmodes)

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -368,7 +368,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         if not utils.isServerName(name):
             raise ValueError('Invalid server name %r' % name)
         self._send_with_prefix(uplink, 'SERVER %s * 1 %s :%s' % (name, sid, desc))
-        self.servers[sid] = IrcServer(uplink, name, internal=True, desc=desc)
+        self.servers[sid] = Server(uplink, name, internal=True, desc=desc)
 
         def endburstf():
             # Delay ENDBURST by X seconds if requested.
@@ -604,7 +604,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
                  raise ProtocolError('Error: recvpass from uplink server %s does not match configuration!' % servername)
 
             sdesc = args[-1]
-            self.servers[numeric] = IrcServer(None, servername, desc=sdesc)
+            self.servers[numeric] = Server(None, servername, desc=sdesc)
             self.uplink = numeric
             return
 
@@ -613,7 +613,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         servername = args[0].lower()
         sid = args[3]
         sdesc = args[-1]
-        self.servers[sid] = IrcServer(numeric, servername, desc=sdesc)
+        self.servers[sid] = Server(numeric, servername, desc=sdesc)
 
         return {'name': servername, 'sid': args[3], 'text': sdesc}
 

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -227,11 +227,11 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
         self._send_with_prefix(numeric, 'KILL %s :Killed (%s (%s))' % (target, sourcenick, reason))
 
-        # We only need to call removeClient here if the target is one of our
+        # We only need to call _remove_client here if the target is one of our
         # clients, since any remote servers will send a QUIT from
         # their target if the command succeeds.
         if self.isInternalClient(target):
-            self.removeClient(target)
+            self._remove_client(target)
 
     def topicBurst(self, numeric, target, text):
         """Sends a topic change from a PyLink server. This is usually used on burst."""
@@ -799,7 +799,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # ourselves.
         data = self.users.get(killed)
         if data:
-            self.removeClient(killed)
+            self._remove_client(killed)
         return {'target': killed, 'text': args[1], 'userdata': data}
 
     def handle_sakick(self, source, command, args):

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -477,7 +477,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
             # USERMODES=,,s,BHIRSWcghikorwx GLOBOPS=1 SVSPART=1
 
             # First, turn the arguments into a dict
-            caps = self.parseCapabilities(args[-1])
+            caps = self.parse_isupport(args[-1])
             log.debug("(%s) capabilities list: %s", self.name, caps)
 
             # Check the protocol version
@@ -508,7 +508,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
             # Separate the prefixes field (e.g. "(Yqaohv)!~&@%+") into a
             # dict mapping mode characters to mode prefixes.
-            self.prefixmodes = self.parsePrefixes(caps['PREFIX'])
+            self.prefixmodes = self.parse_isupport_prefixes(caps['PREFIX'])
             log.debug('(%s) self.prefixmodes set to %r', self.name,
                       self.prefixmodes)
 

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -673,14 +673,6 @@ class InspIRCdProtocol(TS6BaseProtocol):
     # SVSTOPIC is used by InspIRCd module m_topiclock - its arguments are the same as FTOPIC
     handle_svstopic = handle_ftopic
 
-    def handle_invite(self, numeric, command, args):
-        """Handles incoming INVITEs."""
-        # <- :70MAAAAAC INVITE 0ALAAAAAA #blah 0
-        target = args[0]
-        channel = self.toLower(args[1])
-        # We don't actually need to process this; just send the hook so plugins can use it
-        return {'target': target, 'channel': channel}
-
     def handle_knock(self, numeric, command, args):
         """Handles channel KNOCKs."""
         # <- :70MAAAAAA ENCAP * KNOCK #blah :abcdefg

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -233,7 +233,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         if self.is_internal_client(target):
             self._remove_client(target)
 
-    def topicBurst(self, numeric, target, text):
+    def topic_burst(self, numeric, target, text):
         """Sends a topic change from a PyLink server. This is usually used on burst."""
         if not self.is_internal_server(numeric):
             raise LookupError('No such PyLink server exists.')

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -42,9 +42,9 @@ class InspIRCdProtocol(TS6BaseProtocol):
         Note: No nick collision / valid nickname checks are done here; it is
         up to plugins to make sure they don't introduce anything invalid.
         """
-        server = server or self.irc.sid
+        server = server or self.sid
 
-        if not self.irc.isInternalServer(server):
+        if not self.isInternalServer(server):
             raise ValueError('Server %r is not a PyLink server!' % server)
 
         uid = self.uidgen[server].next_uid()
@@ -52,12 +52,12 @@ class InspIRCdProtocol(TS6BaseProtocol):
         ts = ts or int(time.time())
         realname = realname or conf.conf['bot']['realname']
         realhost = realhost or host
-        raw_modes = self.irc.joinModes(modes)
-        u = self.irc.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        raw_modes = self.joinModes(modes)
+        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable, opertype=opertype)
 
-        self.irc.applyModes(uid, modes)
-        self.irc.servers[server].users.add(uid)
+        self.applyModes(uid, modes)
+        self.servers[server].users.add(uid)
 
         self._send_with_prefix(server, "UID {uid} {ts} {nick} {realhost} {host} {ident} {ip}"
                         " {ts} {modes} + :{realname}".format(ts=ts, host=host,
@@ -73,20 +73,20 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # InspIRCd doesn't distinguish between burst joins and regular joins,
         # so what we're actually doing here is sending FJOIN from the server,
         # on behalf of the clients that are joining.
-        channel = self.irc.toLower(channel)
+        channel = self.toLower(channel)
 
-        server = self.irc.getServer(client)
-        if not self.irc.isInternalServer(server):
-            log.error('(%s) Error trying to join %r to %r (no such client exists)', self.irc.name, client, channel)
+        server = self.getServer(client)
+        if not self.isInternalServer(server):
+            log.error('(%s) Error trying to join %r to %r (no such client exists)', self.name, client, channel)
             raise LookupError('No such PyLink client exists.')
 
         # Strip out list-modes, they shouldn't be ever sent in FJOIN.
-        modes = [m for m in self.irc.channels[channel].modes if m[0] not in self.irc.cmodes['*A']]
+        modes = [m for m in self.channels[channel].modes if m[0] not in self.cmodes['*A']]
         self._send_with_prefix(server, "FJOIN {channel} {ts} {modes} :,{uid}".format(
-                ts=self.irc.channels[channel].ts, uid=client, channel=channel,
-                modes=self.irc.joinModes(modes)))
-        self.irc.channels[channel].users.add(client)
-        self.irc.users[client].channels.add(channel)
+                ts=self.channels[channel].ts, uid=client, channel=channel,
+                modes=self.joinModes(modes)))
+        self.channels[channel].users.add(client)
+        self.users[client].channels.add(channel)
 
     def sjoin(self, server, channel, users, ts=None, modes=set()):
         """Sends an SJOIN for a group of users to a channel.
@@ -97,29 +97,29 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
         Example uses:
             sjoin('100', '#test', [('', '100AAABBC'), ('qo', 100AAABBB'), ('h', '100AAADDD')])
-            sjoin(self.irc.sid, '#test', [('o', self.irc.pseudoclient.uid)])
+            sjoin(self.sid, '#test', [('o', self.pseudoclient.uid)])
         """
-        channel = self.irc.toLower(channel)
-        server = server or self.irc.sid
+        channel = self.toLower(channel)
+        server = server or self.sid
         assert users, "sjoin: No users sent?"
-        log.debug('(%s) sjoin: got %r for users', self.irc.name, users)
+        log.debug('(%s) sjoin: got %r for users', self.name, users)
 
         if not server:
             raise LookupError('No such PyLink client exists.')
 
         # Strip out list-modes, they shouldn't ever be sent in FJOIN (protocol rules).
-        modes = modes or self.irc.channels[channel].modes
-        orig_ts = self.irc.channels[channel].ts
+        modes = modes or self.channels[channel].modes
+        orig_ts = self.channels[channel].ts
         ts = ts or orig_ts
 
         banmodes = []
         regularmodes = []
         for mode in modes:
             modechar = mode[0][-1]
-            if modechar in self.irc.cmodes['*A']:
+            if modechar in self.cmodes['*A']:
                 # Track bans separately (they are sent as a normal FMODE instead of in FJOIN.
                 # However, don't reset bans that have already been set.
-                if (modechar, mode[1]) not in self.irc.channels[channel].modes:
+                if (modechar, mode[1]) not in self.channels[channel].modes:
                     banmodes.append(mode)
             else:
                 regularmodes.append(mode)
@@ -137,21 +137,21 @@ class InspIRCdProtocol(TS6BaseProtocol):
             for m in prefixes:
                 changedmodes.add(('+%s' % m, user))
             try:
-                self.irc.users[user].channels.add(channel)
+                self.users[user].channels.add(channel)
             except KeyError:  # Not initialized yet?
-                log.debug("(%s) sjoin: KeyError trying to add %r to %r's channel list?", self.irc.name, channel, user)
+                log.debug("(%s) sjoin: KeyError trying to add %r to %r's channel list?", self.name, channel, user)
 
         namelist = ' '.join(namelist)
         self._send_with_prefix(server, "FJOIN {channel} {ts} {modes} :{users}".format(
                 ts=ts, users=namelist, channel=channel,
-                modes=self.irc.joinModes(modes)))
-        self.irc.channels[channel].users.update(uids)
+                modes=self.joinModes(modes)))
+        self.channels[channel].users.update(uids)
 
         if banmodes:
             # Burst ban modes if there are any.
             # <- :1ML FMODE #test 1461201525 +bb *!*@bad.user *!*@rly.bad.user
             self._send_with_prefix(server, "FMODE {channel} {ts} {modes} ".format(
-                ts=ts, channel=channel, modes=self.irc.joinModes(banmodes)))
+                ts=ts, channel=channel, modes=self.joinModes(banmodes)))
 
         self.updateTS(server, channel, ts, changedmodes)
 
@@ -163,19 +163,19 @@ class InspIRCdProtocol(TS6BaseProtocol):
         recognize ANY non-burst oper ups.
 
         Plugins don't have to call this function themselves, but they can
-        set the opertype attribute of an IrcUser object (in self.irc.users),
+        set the opertype attribute of an IrcUser object (in self.users),
         and the change will be reflected here."""
-        userobj = self.irc.users[target]
+        userobj = self.users[target]
         try:
             otype = opertype or userobj.opertype or 'IRC Operator'
         except AttributeError:
             log.debug('(%s) opertype field for %s (%s) isn\'t filled yet!',
-                      self.irc.name, target, userobj.nick)
+                      self.name, target, userobj.nick)
             # whatever, this is non-standard anyways.
             otype = 'IRC Operator'
         assert otype, "Tried to send an empty OPERTYPE!"
         log.debug('(%s) Sending OPERTYPE from %s to oper them up.',
-                  self.irc.name, target)
+                  self.name, target)
         userobj.opertype = otype
 
         # InspIRCd 2.x uses _ in OPERTYPE to denote spaces, while InspIRCd 3.x does not. This is not
@@ -194,64 +194,64 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # -> :9PYAAAAAA FMODE #pylink 1433653951 +os 9PYAAAAAA
         # -> :9PYAAAAAA MODE 9PYAAAAAA -i+w
 
-        if (not self.irc.isInternalClient(numeric)) and \
-                (not self.irc.isInternalServer(numeric)):
+        if (not self.isInternalClient(numeric)) and \
+                (not self.isInternalServer(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
-        log.debug('(%s) inspircd._send_with_prefixModes: received %r for mode list', self.irc.name, modes)
+        log.debug('(%s) inspircd._send_with_prefixModes: received %r for mode list', self.name, modes)
         if ('+o', None) in modes and not utils.isChannel(target):
             # https://github.com/inspircd/inspircd/blob/master/src/modules/m_spanningtree/opertype.cpp#L26-L28
             # Servers need a special command to set umode +o on people.
             self._operUp(target)
-        self.irc.applyModes(target, modes)
-        joinedmodes = self.irc.joinModes(modes)
+        self.applyModes(target, modes)
+        joinedmodes = self.joinModes(modes)
         if utils.isChannel(target):
-            ts = ts or self.irc.channels[self.irc.toLower(target)].ts
+            ts = ts or self.channels[self.toLower(target)].ts
             self._send_with_prefix(numeric, 'FMODE %s %s %s' % (target, ts, joinedmodes))
         else:
             self._send_with_prefix(numeric, 'MODE %s %s' % (target, joinedmodes))
 
     def kill(self, numeric, target, reason):
         """Sends a kill from a PyLink client/server."""
-        if (not self.irc.isInternalClient(numeric)) and \
-                (not self.irc.isInternalServer(numeric)):
+        if (not self.isInternalClient(numeric)) and \
+                (not self.isInternalServer(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
         # InspIRCd will show the raw kill message sent from our server as the quit message.
         # So, make the kill look actually like a kill instead of someone quitting with
         # an arbitrary message.
-        if numeric in self.irc.servers:
-            sourcenick = self.irc.servers[numeric].name
+        if numeric in self.servers:
+            sourcenick = self.servers[numeric].name
         else:
-            sourcenick = self.irc.users[numeric].nick
+            sourcenick = self.users[numeric].nick
 
         self._send_with_prefix(numeric, 'KILL %s :Killed (%s (%s))' % (target, sourcenick, reason))
 
         # We only need to call removeClient here if the target is one of our
         # clients, since any remote servers will send a QUIT from
         # their target if the command succeeds.
-        if self.irc.isInternalClient(target):
+        if self.isInternalClient(target):
             self.removeClient(target)
 
     def topicBurst(self, numeric, target, text):
         """Sends a topic change from a PyLink server. This is usually used on burst."""
-        if not self.irc.isInternalServer(numeric):
+        if not self.isInternalServer(numeric):
             raise LookupError('No such PyLink server exists.')
         ts = int(time.time())
-        servername = self.irc.servers[numeric].name
+        servername = self.servers[numeric].name
         self._send_with_prefix(numeric, 'FTOPIC %s %s %s :%s' % (target, ts, servername, text))
-        self.irc.channels[target].topic = text
-        self.irc.channels[target].topicset = True
+        self.channels[target].topic = text
+        self.channels[target].topicset = True
 
     def invite(self, numeric, target, channel):
         """Sends an INVITE from a PyLink client.."""
-        if not self.irc.isInternalClient(numeric):
+        if not self.isInternalClient(numeric):
             raise LookupError('No such PyLink client exists.')
         self._send_with_prefix(numeric, 'INVITE %s %s' % (target, channel))
 
     def knock(self, numeric, target, text):
         """Sends a KNOCK from a PyLink client."""
-        if not self.irc.isInternalClient(numeric):
+        if not self.isInternalClient(numeric):
             raise LookupError('No such PyLink client exists.')
         self._send_with_prefix(numeric, 'ENCAP * KNOCK %s :%s' % (target, text))
 
@@ -263,56 +263,56 @@ class InspIRCdProtocol(TS6BaseProtocol):
             raise NotImplementedError("Changing field %r of a client is "
                                       "unsupported by this protocol." % field)
 
-        if self.irc.isInternalClient(target):
+        if self.isInternalClient(target):
             # It is one of our clients, use FIDENT/HOST/NAME.
             if field == 'IDENT':
-                self.irc.users[target].ident = text
+                self.users[target].ident = text
                 self._send_with_prefix(target, 'FIDENT %s' % text)
             elif field == 'HOST':
-                self.irc.users[target].host = text
+                self.users[target].host = text
                 self._send_with_prefix(target, 'FHOST %s' % text)
             elif field in ('REALNAME', 'GECOS'):
-                self.irc.users[target].realname = text
+                self.users[target].realname = text
                 self._send_with_prefix(target, 'FNAME :%s' % text)
         else:
             # It is a client on another server, use CHGIDENT/HOST/NAME.
             if field == 'IDENT':
                 if 'm_chgident.so' not in self.modsupport:
-                    log.warning('(%s) Failed to change ident of %s to %r: load m_chgident.so!', self.irc.name, target, text)
+                    log.warning('(%s) Failed to change ident of %s to %r: load m_chgident.so!', self.name, target, text)
                     return
 
-                self.irc.users[target].ident = text
-                self._send_with_prefix(self.irc.sid, 'CHGIDENT %s %s' % (target, text))
+                self.users[target].ident = text
+                self._send_with_prefix(self.sid, 'CHGIDENT %s %s' % (target, text))
 
                 # Send hook payloads for other plugins to listen to.
-                self.irc.callHooks([self.irc.sid, 'CHGIDENT',
+                self.callHooks([self.sid, 'CHGIDENT',
                                    {'target': target, 'newident': text}])
             elif field == 'HOST':
                 if 'm_chghost.so' not in self.modsupport:
-                    log.warning('(%s) Failed to change host of %s to %r: load m_chghost.so!', self.irc.name, target, text)
+                    log.warning('(%s) Failed to change host of %s to %r: load m_chghost.so!', self.name, target, text)
                     return
 
-                self.irc.users[target].host = text
-                self._send_with_prefix(self.irc.sid, 'CHGHOST %s %s' % (target, text))
+                self.users[target].host = text
+                self._send_with_prefix(self.sid, 'CHGHOST %s %s' % (target, text))
 
-                self.irc.callHooks([self.irc.sid, 'CHGHOST',
+                self.callHooks([self.sid, 'CHGHOST',
                                    {'target': target, 'newhost': text}])
 
             elif field in ('REALNAME', 'GECOS'):
                 if 'm_chgname.so' not in self.modsupport:
-                    log.warning('(%s) Failed to change real name of %s to %r: load m_chgname.so!', self.irc.name, target, text)
+                    log.warning('(%s) Failed to change real name of %s to %r: load m_chgname.so!', self.name, target, text)
                     return
-                self.irc.users[target].realname = text
-                self._send_with_prefix(self.irc.sid, 'CHGNAME %s :%s' % (target, text))
+                self.users[target].realname = text
+                self._send_with_prefix(self.sid, 'CHGNAME %s :%s' % (target, text))
 
-                self.irc.callHooks([self.irc.sid, 'CHGNAME',
+                self.callHooks([self.sid, 'CHGNAME',
                                    {'target': target, 'newgecos': text}])
 
     def ping(self, source=None, target=None):
         """Sends a PING to a target server. Periodic PINGs are sent to our uplink
         automatically by the Irc() internals; plugins shouldn't have to use this."""
-        source = source or self.irc.sid
-        target = target or self.irc.uplink
+        source = source or self.sid
+        target = target or self.uplink
         if not (target is None or source is None):
             self._send_with_prefix(source, 'PING %s %s' % (source, target))
 
@@ -327,7 +327,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # :<sid> NUM <numeric source sid> <target uuid> <3 digit number> <params>
         # Take this into consideration if we ever target InspIRCd 2.2, even though m_spanningtree
         # does provide backwards compatibility for commands like this. -GLolol
-        self._send_with_prefix(self.irc.sid, 'PUSH %s ::%s %s %s %s' % (target, source, numeric, target, text))
+        self._send_with_prefix(self.sid, 'PUSH %s ::%s %s %s %s' % (target, source, numeric, target, text))
 
     def away(self, source, text):
         """Sends an AWAY message from a PyLink client. <text> can be an empty string
@@ -336,7 +336,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
             self._send_with_prefix(source, 'AWAY %s :%s' % (int(time.time()), text))
         else:
             self._send_with_prefix(source, 'AWAY')
-        self.irc.users[source].away = text
+        self.users[source].away = text
 
     def spawnServer(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
         """
@@ -351,30 +351,30 @@ class InspIRCdProtocol(TS6BaseProtocol):
         and prevent connections from filling up the snomasks too much.
         """
         # -> :0AL SERVER test.server * 1 0AM :some silly pseudoserver
-        uplink = uplink or self.irc.sid
+        uplink = uplink or self.sid
         name = name.lower()
         # "desc" defaults to the configured server description.
-        desc = desc or self.irc.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']
+        desc = desc or self.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']
         if sid is None:  # No sid given; generate one!
             sid = self.sidgen.next_sid()
         assert len(sid) == 3, "Incorrect SID length"
-        if sid in self.irc.servers:
+        if sid in self.servers:
             raise ValueError('A server with SID %r already exists!' % sid)
-        for server in self.irc.servers.values():
+        for server in self.servers.values():
             if name == server.name:
                 raise ValueError('A server named %r already exists!' % name)
-        if not self.irc.isInternalServer(uplink):
+        if not self.isInternalServer(uplink):
             raise ValueError('Server %r is not a PyLink server!' % uplink)
         if not utils.isServerName(name):
             raise ValueError('Invalid server name %r' % name)
         self._send_with_prefix(uplink, 'SERVER %s * 1 %s :%s' % (name, sid, desc))
-        self.irc.servers[sid] = IrcServer(uplink, name, internal=True, desc=desc)
+        self.servers[sid] = IrcServer(uplink, name, internal=True, desc=desc)
 
         def endburstf():
             # Delay ENDBURST by X seconds if requested.
-            if self.irc.aborted.wait(endburst_delay):
+            if self.aborted.wait(endburst_delay):
                 # We managed to catch the abort flag before sending ENDBURST, so break
-                log.debug('(%s) stopping endburstf() for %s as aborted was set', self.irc.name, sid)
+                log.debug('(%s) stopping endburstf() for %s as aborted was set', self.name, sid)
                 return
             self._send_with_prefix(sid, 'ENDBURST')
 
@@ -394,25 +394,25 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
     def post_connect(self):
         """Initializes a connection to a server."""
-        ts = self.irc.start_ts
+        ts = self.start_ts
 
         # Track the modules supported by the uplink.
         self.modsupport = []
 
-        f = self.irc.send
+        f = self.send
         f('CAPAB START %s' % self.proto_ver)
         f('CAPAB CAPABILITIES :PROTOCOL=%s' % self.proto_ver)
         f('CAPAB END')
 
-        host = self.irc.serverdata["hostname"]
+        host = self.serverdata["hostname"]
         f('SERVER {host} {Pass} 0 {sid} :{sdesc}'.format(host=host,
-          Pass=self.irc.serverdata["sendpass"], sid=self.irc.sid,
-          sdesc=self.irc.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']))
+          Pass=self.serverdata["sendpass"], sid=self.sid,
+          sdesc=self.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']))
 
-        self._send_with_prefix(self.irc.sid, 'BURST %s' % ts)
+        self._send_with_prefix(self.sid, 'BURST %s' % ts)
         # InspIRCd sends VERSION data on link, instead of whenever requested by a client.
-        self._send_with_prefix(self.irc.sid, 'VERSION :%s' % self.irc.version())
-        self._send_with_prefix(self.irc.sid, 'ENDBURST')
+        self._send_with_prefix(self.sid, 'VERSION :%s' % self.version())
+        self._send_with_prefix(self.sid, 'ENDBURST')
 
     def handle_capab(self, source, command, args):
         """
@@ -453,7 +453,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
                     name = 'owner'
 
                 # We don't care about mode prefixes; just the mode char.
-                self.irc.cmodes[name] = char[-1]
+                self.cmodes[name] = char[-1]
 
 
         elif args[0] == 'USERMODES':
@@ -467,7 +467,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
                 name, char = modepair.split('=')
                 # Strip u_ prefixes to be consistent with other protocols.
                 name = name.lstrip('u_')
-                self.irc.umodes[name] = char
+                self.umodes[name] = char
 
         elif args[0] == 'CAPABILITIES':
             # <- CAPAB CAPABILITIES :NICKMAX=21 CHANMAX=64 MAXMODES=20
@@ -478,7 +478,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
             # First, turn the arguments into a dict
             caps = self.parseCapabilities(args[-1])
-            log.debug("(%s) capabilities list: %s", self.irc.name, caps)
+            log.debug("(%s) capabilities list: %s", self.name, caps)
 
             # Check the protocol version
             self.remote_proto_ver = protocol_version = int(caps['PROTOCOL'])
@@ -491,30 +491,30 @@ class InspIRCdProtocol(TS6BaseProtocol):
             elif protocol_version > self.max_proto_ver:
                 log.warning("(%s) PyLink support for InspIRCd 2.2+ is experimental, "
                             "and should not be relied upon for anything important.",
-                            self.irc.name)
+                            self.name)
 
             # Store the max nick and channel lengths
-            self.irc.maxnicklen = int(caps['NICKMAX'])
-            self.irc.maxchanlen = int(caps['CHANMAX'])
+            self.maxnicklen = int(caps['NICKMAX'])
+            self.maxchanlen = int(caps['CHANMAX'])
 
             # Modes are divided into A, B, C, and D classes
             # See http://www.irc.org/tech_docs/005.html
 
             # FIXME: Find a neater way to assign/store this.
-            self.irc.cmodes['*A'], self.irc.cmodes['*B'], self.irc.cmodes['*C'], self.irc.cmodes['*D'] \
+            self.cmodes['*A'], self.cmodes['*B'], self.cmodes['*C'], self.cmodes['*D'] \
                 = caps['CHANMODES'].split(',')
-            self.irc.umodes['*A'], self.irc.umodes['*B'], self.irc.umodes['*C'], self.irc.umodes['*D'] \
+            self.umodes['*A'], self.umodes['*B'], self.umodes['*C'], self.umodes['*D'] \
                 = caps['USERMODES'].split(',')
 
             # Separate the prefixes field (e.g. "(Yqaohv)!~&@%+") into a
             # dict mapping mode characters to mode prefixes.
-            self.irc.prefixmodes = self.parsePrefixes(caps['PREFIX'])
-            log.debug('(%s) self.irc.prefixmodes set to %r', self.irc.name,
-                      self.irc.prefixmodes)
+            self.prefixmodes = self.parsePrefixes(caps['PREFIX'])
+            log.debug('(%s) self.prefixmodes set to %r', self.name,
+                      self.prefixmodes)
 
             # Finally, set the irc.connected (protocol negotiation complete)
             # state to True.
-            self.irc.connected.set()
+            self.connected.set()
         elif args[0] == 'MODSUPPORT':
             # <- CAPAB MODSUPPORT :m_alltime.so m_check.so m_chghost.so m_chgident.so m_chgname.so m_fullversion.so m_gecosban.so m_knock.so m_muteban.so m_nicklock.so m_nopartmsg.so m_opmoderated.so m_sajoin.so m_sanick.so m_sapart.so m_serverban.so m_services_account.so m_showwhois.so m_silence.so m_swhois.so m_uninvite.so m_watch.so
             self.modsupport = args[-1].split()
@@ -523,19 +523,19 @@ class InspIRCdProtocol(TS6BaseProtocol):
         """Handles incoming PING commands, so we don't time out."""
         # <- :70M PING 70M 0AL
         # -> :0AL PONG 0AL 70M
-        if self.irc.isInternalServer(args[1]):
+        if self.isInternalServer(args[1]):
             self._send_with_prefix(args[1], 'PONG %s %s' % (args[1], source), queue=False)
 
     def handle_fjoin(self, servernumeric, command, args):
         """Handles incoming FJOIN commands (InspIRCd equivalent of JOIN/SJOIN)."""
         # :70M FJOIN #chat 1423790411 +AFPfjnt 6:5 7:5 9:5 :o,1SRAABIT4 v,1IOAAF53R <...>
-        channel = self.irc.toLower(args[0])
-        chandata = self.irc.channels[channel].deepcopy()
+        channel = self.toLower(args[0])
+        chandata = self.channels[channel].deepcopy()
         # InspIRCd sends each channel's users in the form of 'modeprefix(es),UID'
         userlist = args[-1].split()
 
         modestring = args[2:-1] or args[2]
-        parsedmodes = self.irc.parseModes(channel, modestring)
+        parsedmodes = self.parseModes(channel, modestring)
         namelist = []
 
         # Keep track of other modes that are added due to prefix modes being joined too.
@@ -545,18 +545,18 @@ class InspIRCdProtocol(TS6BaseProtocol):
             modeprefix, user = user.split(',', 1)
 
             # Don't crash when we get an invalid UID.
-            if user not in self.irc.users:
+            if user not in self.users:
                 log.debug('(%s) handle_fjoin: tried to introduce user %s not in our user list, ignoring...',
-                          self.irc.name, user)
+                          self.name, user)
                 continue
 
             namelist.append(user)
-            self.irc.users[user].channels.add(channel)
+            self.users[user].channels.add(channel)
 
             # Only save mode changes if the remote has lower TS than us.
             changedmodes |= {('+%s' % mode, user) for mode in modeprefix}
 
-            self.irc.channels[channel].users.add(user)
+            self.channels[channel].users.add(user)
 
         # Statekeeping with timestamps. Note: some service packages (Anope 1.8) send a trailing
         # 'd' after the timestamp, which we should strip out to prevent int() from erroring.
@@ -565,7 +565,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # <- :3AX FJOIN #monitor 1485462109d + :,3AXAAAAAK
         their_ts = int(''.join(char for char in args[1] if char.isdigit()))
 
-        our_ts = self.irc.channels[channel].ts
+        our_ts = self.channels[channel].ts
         self.updateTS(servernumeric, channel, their_ts, changedmodes)
 
         return {'channel': channel, 'users': namelist, 'modes': parsedmodes, 'ts': their_ts,
@@ -577,35 +577,35 @@ class InspIRCdProtocol(TS6BaseProtocol):
         uid, ts, nick, realhost, host, ident, ip = args[0:7]
         self.check_nick_collision(nick)
         realname = args[-1]
-        self.irc.users[uid] = userobj = IrcUser(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
+        self.users[uid] = userobj = IrcUser(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
 
-        parsedmodes = self.irc.parseModes(uid, [args[8], args[9]])
-        self.irc.applyModes(uid, parsedmodes)
+        parsedmodes = self.parseModes(uid, [args[8], args[9]])
+        self.applyModes(uid, parsedmodes)
 
-        if (self.irc.umodes.get('servprotect'), None) in userobj.modes:
+        if (self.umodes.get('servprotect'), None) in userobj.modes:
             # Services are usually given a "Network Service" WHOIS, so
             # set that as the opertype.
-            self.irc.callHooks([uid, 'CLIENT_OPERED', {'text': 'Network Service'}])
+            self.callHooks([uid, 'CLIENT_OPERED', {'text': 'Network Service'}])
 
-        self.irc.servers[numeric].users.add(uid)
+        self.servers[numeric].users.add(uid)
         return {'uid': uid, 'ts': ts, 'nick': nick, 'realhost': realhost, 'host': host, 'ident': ident, 'ip': ip}
 
     def handle_server(self, numeric, command, args):
         """Handles incoming SERVER commands (introduction of servers)."""
 
         # Initial SERVER command on connect.
-        if self.irc.uplink is None:
+        if self.uplink is None:
             # <- SERVER whatever.net abcdefgh 0 10X :some server description
             servername = args[0].lower()
             numeric = args[3]
 
-            if args[1] != self.irc.serverdata['recvpass']:
+            if args[1] != self.serverdata['recvpass']:
                  # Check if recvpass is correct
                  raise ProtocolError('Error: recvpass from uplink server %s does not match configuration!' % servername)
 
             sdesc = args[-1]
-            self.irc.servers[numeric] = IrcServer(None, servername, desc=sdesc)
-            self.irc.uplink = numeric
+            self.servers[numeric] = IrcServer(None, servername, desc=sdesc)
+            self.uplink = numeric
             return
 
         # Other server introductions.
@@ -613,18 +613,18 @@ class InspIRCdProtocol(TS6BaseProtocol):
         servername = args[0].lower()
         sid = args[3]
         sdesc = args[-1]
-        self.irc.servers[sid] = IrcServer(numeric, servername, desc=sdesc)
+        self.servers[sid] = IrcServer(numeric, servername, desc=sdesc)
 
         return {'name': servername, 'sid': args[3], 'text': sdesc}
 
     def handle_fmode(self, numeric, command, args):
         """Handles the FMODE command, used for channel mode changes."""
         # <- :70MAAAAAA FMODE #chat 1433653462 +hhT 70MAAAAAA 70MAAAAAD
-        channel = self.irc.toLower(args[0])
-        oldobj = self.irc.channels[channel].deepcopy()
+        channel = self.toLower(args[0])
+        oldobj = self.channels[channel].deepcopy()
         modes = args[2:]
-        changedmodes = self.irc.parseModes(channel, modes)
-        self.irc.applyModes(channel, changedmodes)
+        changedmodes = self.parseModes(channel, modes)
+        self.applyModes(channel, changedmodes)
         ts = int(args[1])
         return {'target': channel, 'modes': changedmodes, 'ts': ts,
                 'channeldata': oldobj}
@@ -636,8 +636,8 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # <- :70MAAAAAA MODE 70MAAAAAA -i+xc
         target = args[0]
         modestrings = args[1:]
-        changedmodes = self.irc.parseModes(target, modestrings)
-        self.irc.applyModes(target, changedmodes)
+        changedmodes = self.parseModes(target, modestrings)
+        self.applyModes(target, changedmodes)
         return {'target': target, 'modes': changedmodes}
 
     def handle_idle(self, numeric, command, args):
@@ -662,12 +662,12 @@ class InspIRCdProtocol(TS6BaseProtocol):
     def handle_ftopic(self, numeric, command, args):
         """Handles incoming FTOPIC (sets topic on burst)."""
         # <- :70M FTOPIC #channel 1434510754 GLo|o|!GLolol@escape.the.dreamland.ca :Some channel topic
-        channel = self.irc.toLower(args[0])
+        channel = self.toLower(args[0])
         ts = args[1]
         setter = args[2]
         topic = args[-1]
-        self.irc.channels[channel].topic = topic
-        self.irc.channels[channel].topicset = True
+        self.channels[channel].topic = topic
+        self.channels[channel].topicset = True
         return {'channel': channel, 'setter': setter, 'ts': ts, 'text': topic}
 
     # SVSTOPIC is used by InspIRCd module m_topiclock - its arguments are the same as FTOPIC
@@ -677,14 +677,14 @@ class InspIRCdProtocol(TS6BaseProtocol):
         """Handles incoming INVITEs."""
         # <- :70MAAAAAC INVITE 0ALAAAAAA #blah 0
         target = args[0]
-        channel = self.irc.toLower(args[1])
+        channel = self.toLower(args[1])
         # We don't actually need to process this; just send the hook so plugins can use it
         return {'target': target, 'channel': channel}
 
     def handle_knock(self, numeric, command, args):
         """Handles channel KNOCKs."""
         # <- :70MAAAAAA ENCAP * KNOCK #blah :abcdefg
-        channel = self.irc.toLower(args[0])
+        channel = self.toLower(args[0])
         text = args[1]
         return {'channel': channel, 'text': text}
 
@@ -701,29 +701,29 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
         # Set umode +o on the target.
         omode = [('+o', None)]
-        self.irc.applyModes(target, omode)
+        self.applyModes(target, omode)
 
         # Call the CLIENT_OPERED hook that protocols use. The MODE hook
         # payload is returned below.
-        self.irc.callHooks([target, 'CLIENT_OPERED', {'text': opertype}])
+        self.callHooks([target, 'CLIENT_OPERED', {'text': opertype}])
         return {'target': target, 'modes': omode}
 
     def handle_fident(self, numeric, command, args):
         """Handles FIDENT, used for denoting ident changes."""
         # <- :70MAAAAAB FIDENT test
-        self.irc.users[numeric].ident = newident = args[0]
+        self.users[numeric].ident = newident = args[0]
         return {'target': numeric, 'newident': newident}
 
     def handle_fhost(self, numeric, command, args):
         """Handles FHOST, used for denoting hostname changes."""
         # <- :70MAAAAAB FHOST some.host
-        self.irc.users[numeric].host = newhost = args[0]
+        self.users[numeric].host = newhost = args[0]
         return {'target': numeric, 'newhost': newhost}
 
     def handle_fname(self, numeric, command, args):
         """Handles FNAME, used for denoting real name/gecos changes."""
         # <- :70MAAAAAB FNAME :afdsafasf
-        self.irc.users[numeric].realname = newgecos = args[0]
+        self.users[numeric].realname = newgecos = args[0]
         return {'target': numeric, 'newgecos': newgecos}
 
     def handle_endburst(self, numeric, command, args):
@@ -735,10 +735,10 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # <- :1MLAAAAIG AWAY 1439371390 :Auto-away
         try:
             ts = args[0]
-            self.irc.users[numeric].away = text = args[1]
+            self.users[numeric].away = text = args[1]
             return {'text': text, 'ts': ts}
         except IndexError:  # User is unsetting away status
-            self.irc.users[numeric].away = ''
+            self.users[numeric].away = ''
             return {'text': ''}
 
     def handle_rsquit(self, numeric, command, args):
@@ -760,15 +760,15 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # SQUIT, in order to be consistent with other IRCds which make SQUITs
         # implicit.
         target = self._get_SID(args[0])
-        if self.irc.isInternalServer(target):
+        if self.isInternalServer(target):
             # The target has to be one of our servers in order to work...
-            uplink = self.irc.servers[target].uplink
-            reason = 'Requested by %s' % self.irc.getHostmask(numeric)
+            uplink = self.servers[target].uplink
+            reason = 'Requested by %s' % self.getHostmask(numeric)
             self._send_with_prefix(uplink, 'SQUIT %s :%s' % (target, reason))
             return self.handle_squit(numeric, 'SQUIT', [target, reason])
         else:
             log.debug("(%s) Got RSQUIT for '%s', which is either invalid or not "
-                      "a server of ours!", self.irc.name, args[0])
+                      "a server of ours!", self.name, args[0])
 
     def handle_metadata(self, numeric, command, args):
         """
@@ -777,12 +777,12 @@ class InspIRCdProtocol(TS6BaseProtocol):
         """
         uid = args[0]
 
-        if args[1] == 'accountname' and uid in self.irc.users:
+        if args[1] == 'accountname' and uid in self.users:
             # <- :00A METADATA 1MLAAAJET accountname :
             # <- :00A METADATA 1MLAAAJET accountname :tester
             # Sets the services login name of the client.
 
-            self.irc.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': args[-1]}])
+            self.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': args[-1]}])
 
     def handle_version(self, numeric, command, args):
         """
@@ -797,7 +797,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # removed from our user list.
         # If not, we have to assume that KILL = QUIT and remove them
         # ourselves.
-        data = self.irc.users.get(killed)
+        data = self.users.get(killed)
         if data:
             self.removeClient(killed)
         return {'target': killed, 'text': args[1], 'userdata': data}
@@ -808,20 +808,20 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # ENCAP -> SAKICK args: ['#test', '0ALAAAAAB', 'test']
 
         target = args[1]
-        channel = self.irc.toLower(args[0])
+        channel = self.toLower(args[0])
         try:
             reason = args[2]
         except IndexError:
             # Kick reason is optional, strange...
-            reason = self.irc.getFriendlyName(source)
+            reason = self.getFriendlyName(source)
 
-        if not self.irc.isInternalClient(target):
-            log.warning("(%s) Got SAKICK for client that not one of ours: %s", self.irc.name, target)
+        if not self.isInternalClient(target):
+            log.warning("(%s) Got SAKICK for client that not one of ours: %s", self.name, target)
             return
         else:
             # Like RSQUIT, SAKICK requires that the receiving server acknowledge that a kick has
             # happened. This comes from the server hosting the target client.
-            server = self.irc.getServer(target)
+            server = self.getServer(target)
 
         self.kick(server, channel, target, reason)
         return {'channel': channel, 'target': target, 'text': reason}
@@ -833,6 +833,6 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
         # XXX: We override notice() here because that abstraction doesn't allow messages from servers.
         timestring = '%s (%s)' % (time.strftime('%Y-%m-%d %H:%M:%S'), int(time.time()))
-        self._send_with_prefix(self.irc.sid, 'NOTICE %s :System time is %s on %s' % (source, timestring, self.irc.hostname()))
+        self._send_with_prefix(self.sid, 'NOTICE %s :System time is %s on %s' % (source, timestring, self.hostname()))
 
 Class = InspIRCdProtocol

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -759,7 +759,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
         # If we receive such a remote SQUIT, just forward it as a regular
         # SQUIT, in order to be consistent with other IRCds which make SQUITs
         # implicit.
-        target = self._getSid(args[0])
+        target = self._get_SID(args[0])
         if self.irc.isInternalServer(target):
             # The target has to be one of our servers in order to work...
             uplink = self.irc.servers[target].uplink

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -11,8 +11,8 @@ from pylinkirc.log import log
 from pylinkirc.protocols.ts6_common import *
 
 class InspIRCdProtocol(TS6BaseProtocol):
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.protocol_caps |= {'slash-in-nicks', 'slash-in-hosts', 'underscore-in-hosts'}
 
@@ -392,7 +392,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
 
     ### Core / command handlers
 
-    def connect(self):
+    def post_connect(self):
         """Initializes a connection to a server."""
         ts = self.irc.start_ts
 

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -338,7 +338,7 @@ class InspIRCdProtocol(TS6BaseProtocol):
             self._send_with_prefix(source, 'AWAY')
         self.users[source].away = text
 
-    def spawnServer(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
+    def spawn_server(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
         """
         Spawns a server off a PyLink server. desc (server description)
         defaults to the one in the config. uplink defaults to the main PyLink

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -6,11 +6,11 @@ import time
 import re
 from collections import defaultdict
 
-from pylinkirc.classes import Protocol
+from pylinkirc.classes import IRCNetwork
 from pylinkirc.log import log
 from pylinkirc import utils
 
-class IRCCommonProtocol(Protocol):
+class IRCCommonProtocol(IRCNetwork):
     def validateServerConf(self):
         """Validates that the server block given contains the required keys."""
         for k in self.conf_keys:

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -51,7 +51,7 @@ class IRCCommonProtocol(Protocol):
     def _squit(self, numeric, command, args):
         """Handles incoming SQUITs."""
 
-        split_server = self._getSid(args[0])
+        split_server = self._get_SID(args[0])
 
         # Normally we'd only need to check for our SID as the SQUIT target, but Nefarious
         # actually uses the uplink server as the SQUIT target.
@@ -165,7 +165,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         sender = sender.lstrip(':')
 
         # If the sender isn't in numeric format, try to convert it automatically.
-        sender_sid = self._getSid(sender)
+        sender_sid = self._get_SID(sender)
         sender_uid = self._get_UID(sender)
 
         if sender_sid in self.irc.servers:

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -95,6 +95,7 @@ class IRCS2SProtocol(Protocol):
         # We use lowercase channels internally, but uppercase UIDs.
         # Strip the target of leading prefix modes (for targets like @#channel)
         # before checking whether it's actually a channel.
+
         split_channel = target.split('#', 1)
         if len(split_channel) >= 2 and utils.isChannel('#' + split_channel[1]):
             # Note: don't mess with the case of the channel prefix, or ~#channel

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -179,7 +179,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
             sender = self.uplink
             args.insert(0, sender)
 
-        if self.isInternalClient(sender) or self.isInternalServer(sender):
+        if self.is_internal_client(sender) or self.is_internal_server(sender):
             log.warning("(%s) Received command %s being routed the wrong way!", self.name, command)
             return
 
@@ -213,13 +213,13 @@ class IRCS2SProtocol(IRCCommonProtocol):
         """
         Nick collision checker.
         """
-        uid = self.nickToUid(nick)
+        uid = self.nick_to_uid(nick)
         # If there is a nick collision, we simply alert plugins. Relay will purposely try to
         # lose fights and tag nicks instead, while other plugins can choose how to handle this.
         if uid:
             log.info('(%s) Nick collision on %s/%s, forwarding this to plugins', self.name,
                      uid, nick)
-            self.callHooks([self.sid, 'SAVE', {'target': uid}])
+            self.call_hooks([self.sid, 'SAVE', {'target': uid}])
 
     def handle_away(self, numeric, command, args):
         """Handles incoming AWAY messages."""
@@ -243,7 +243,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         #  Note that the target is a nickname, not a numeric.
 
         target = self._get_UID(args[0])
-        channel = self.toLower(args[1])
+        channel = self.to_lower(args[1])
 
         curtime = int(time.time())
         try:
@@ -274,7 +274,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
 
         try:
             # Get the nick or server name of the caller.
-            killer = self.getFriendlyName(source)
+            killer = self.get_friendly_name(source)
         except KeyError:
             # Killer was... neither? We must have aliens or something. Fallback
             # to the given "UID".
@@ -289,7 +289,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
 
     def handle_part(self, source, command, args):
         """Handles incoming PART commands."""
-        channels = self.toLower(args[0]).split(',')
+        channels = self.to_lower(args[0]).split(',')
 
         for channel in channels:
             self.channels[channel].removeuser(source)
@@ -337,7 +337,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
             # Note: don't mess with the case of the channel prefix, or ~#channel
             # messages will break on RFC1459 casemapping networks (it becomes ^#channel
             # instead).
-            target = '#'.join((split_channel[0], self.toLower(split_channel[1])))
+            target = '#'.join((split_channel[0], self.to_lower(split_channel[1])))
             log.debug('(%s) Normalizing channel target %s to %s', self.name, args[0], target)
 
         return {'target': target, 'text': args[1]}

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -186,7 +186,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         raw_command = args[1].upper()
         args = args[2:]
 
-        log.debug('(%s) Found message sender as %s', self.name, sender)
+        log.debug('(%s) Found message sender as %s, raw_command=%r, args=%r', self.name, sender, raw_command, args)
 
         # For P10, convert the command token into a regular command, if present.
         command = self.COMMAND_TOKENS.get(raw_command, raw_command)

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -11,7 +11,7 @@ from pylinkirc.log import log
 from pylinkirc import utils
 
 class IRCCommonProtocol(IRCNetwork):
-    def validateServerConf(self):
+    def validate_server_conf(self):
         """Validates that the server block given contains the required keys."""
         for k in self.conf_keys:
             assert k in self.irc.serverdata, "Missing option %r in server block for network %s." % (k, self.irc.name)
@@ -142,8 +142,8 @@ class IRCCommonProtocol(IRCNetwork):
 class IRCS2SProtocol(IRCCommonProtocol):
     COMMAND_TOKENS = {}
 
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.protocol_caps = {'can-spawn-clients', 'has-ts', 'can-host-relay',
                               'can-track-servers'}
 

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -292,7 +292,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         channels = self.to_lower(args[0]).split(',')
 
         for channel in channels:
-            self.channels[channel].removeuser(source)
+            self.channels[channel].remove_user(source)
             try:
                 self.users[source].channels.discard(channel)
             except KeyError:

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -20,7 +20,7 @@ class IRCCommonProtocol(IRCNetwork):
         assert type(port) == int and 0 < port < 65535, "Invalid port %r for network %s" % (port, self.name)
 
     @staticmethod
-    def parseArgs(args):
+    def parse_args(args):
         """
         Parses a string or list of of RFC1459-style arguments, where ":" may
         be used for multi-word arguments that last until the end of a line.
@@ -41,10 +41,10 @@ class IRCCommonProtocol(IRCNetwork):
         return real_args
 
     @classmethod
-    def parsePrefixedArgs(cls, args):
-        """Similar to parseArgs(), but stripping leading colons from the first argument
+    def parse_prefixed_args(cls, args):
+        """Similar to parse_args(), but stripping leading colons from the first argument
         of a line (usually the sender field)."""
-        args = cls.parseArgs(args)
+        args = cls.parse_args(args)
         args[0] = args[0].split(':', 1)[1]
         return args
 
@@ -106,7 +106,7 @@ class IRCCommonProtocol(IRCNetwork):
                 'channeldata': old_channels}
 
     @staticmethod
-    def parseCapabilities(args, fallback=''):
+    def parse_isupport(args, fallback=''):
         """
         Parses a string of capabilities in the 005 / RPL_ISUPPORT format.
         """
@@ -127,7 +127,7 @@ class IRCCommonProtocol(IRCNetwork):
         return caps
 
     @staticmethod
-    def parsePrefixes(args):
+    def parse_isupport_prefixes(args):
         """
         Separates prefixes field like "(qaohv)~&@%+" into a dict mapping mode characters to mode
         prefixes.
@@ -159,7 +159,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         the SID of the uplink server.
         """
         data = data.split(" ")
-        args = self.parseArgs(data)
+        args = self.parse_args(data)
 
         sender = args[0]
         sender = sender.lstrip(':')

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -166,7 +166,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
 
         # If the sender isn't in numeric format, try to convert it automatically.
         sender_sid = self._getSid(sender)
-        sender_uid = self._getUid(sender)
+        sender_uid = self._get_UID(sender)
 
         if sender_sid in self.irc.servers:
             # Sender is a server (converting from name to SID gave a valid result).
@@ -217,7 +217,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         # P10:
         # <- ABAAA P AyAAA :privmsg text
         # <- ABAAA O AyAAA :notice text
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
 
         # Coerse =#channel from Charybdis op moderated +z to @#channel.
         if target.startswith('='):
@@ -316,7 +316,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         # WHOIS commands received are for us, since we don't host any real servers
         # to route it to.
 
-        return {'target': self._getUid(args[-1])}
+        return {'target': self._get_UID(args[-1])}
 
     def handle_quit(self, numeric, command, args):
         """Handles incoming QUIT commands."""

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -6,7 +6,7 @@ import time
 import re
 from collections import defaultdict
 
-from pylinkirc.classes import IRCNetwork
+from pylinkirc.classes import IRCNetwork, ProtocolError
 from pylinkirc.log import log
 from pylinkirc import utils
 

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -92,7 +92,7 @@ class IRCCommonProtocol(IRCNetwork):
                     affected_nicks[name].append(nick)
 
             log.debug('Removing client %s (%s)', user, nick)
-            self.removeClient(user)
+            self._remove_client(user)
 
         serverdata = self.servers[split_server]
         sname = serverdata.name
@@ -261,7 +261,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         # ourselves.
         data = self.users.get(killed)
         if data:
-            self.removeClient(killed)
+            self._remove_client(killed)
 
         # TS6-style kills look something like this:
         # <- :GL KILL 38QAAAAAA :hidden-1C620195!GL (test)
@@ -324,7 +324,7 @@ class IRCS2SProtocol(IRCCommonProtocol):
         # <- :1SRAAGB4T QUIT :Quit: quit message goes here
         # P10:
         # <- ABAAB Q :Killed (GL_ (bangbang))
-        self.removeClient(numeric)
+        self._remove_client(numeric)
         return {'text': args[0]}
 
     def handle_time(self, numeric, command, args):

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -234,6 +234,27 @@ class IRCS2SProtocol(IRCCommonProtocol):
             self.users[numeric].away = text = ''
         return {'text': text}
 
+    def handle_invite(self, numeric, command, args):
+        """Handles incoming INVITEs."""
+        # TS6:
+        #  <- :70MAAAAAC INVITE 0ALAAAAAA #blah 12345
+        # P10:
+        #  <- ABAAA I PyLink-devel #services 1460948992
+        #  Note that the target is a nickname, not a numeric.
+
+        target = self._get_UID(args[0])
+        channel = self.toLower(args[1])
+
+        curtime = int(time.time())
+        try:
+            ts = int(args[2])
+        except IndexError:
+            ts = curtime
+
+        ts = ts or curtime  # Treat 0 timestamps (e.g. inspircd) as the current time.
+
+        return {'target': target, 'channel': channel, 'ts': ts}
+
     def handle_kill(self, source, command, args):
         """Handles incoming KILLs."""
         killed = args[0]

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -3,12 +3,143 @@ ircs2s_common.py: Common base protocol class with functions shared by TS6 and P1
 """
 
 import time
+import re
+from collections import defaultdict
 
 from pylinkirc.classes import Protocol
 from pylinkirc.log import log
 from pylinkirc import utils
 
-class IRCS2SProtocol(Protocol):
+class IRCCommonProtocol(Protocol):
+    def validateServerConf(self):
+        """Validates that the server block given contains the required keys."""
+        for k in self.conf_keys:
+            assert k in self.irc.serverdata, "Missing option %r in server block for network %s." % (k, self.irc.name)
+
+        port = self.irc.serverdata['port']
+        assert type(port) == int and 0 < port < 65535, "Invalid port %r for network %s" % (port, self.irc.name)
+
+    @staticmethod
+    def parseArgs(args):
+        """
+        Parses a string or list of of RFC1459-style arguments, where ":" may
+        be used for multi-word arguments that last until the end of a line.
+        """
+        if isinstance(args, str):
+            args = args.split(' ')
+
+        real_args = []
+        for idx, arg in enumerate(args):
+            if arg.startswith(':') and idx != 0:
+                # ":" is used to begin multi-word arguments that last until the end of the message.
+                # Use list splicing here to join them into one argument, and then add it to our list of args.
+                joined_arg = ' '.join(args[idx:])[1:]  # Cut off the leading : as well
+                real_args.append(joined_arg)
+                break
+            real_args.append(arg)
+
+        return real_args
+
+    @classmethod
+    def parsePrefixedArgs(cls, args):
+        """Similar to parseArgs(), but stripping leading colons from the first argument
+        of a line (usually the sender field)."""
+        args = cls.parseArgs(args)
+        args[0] = args[0].split(':', 1)[1]
+        return args
+
+    def _squit(self, numeric, command, args):
+        """Handles incoming SQUITs."""
+
+        split_server = self._getSid(args[0])
+
+        # Normally we'd only need to check for our SID as the SQUIT target, but Nefarious
+        # actually uses the uplink server as the SQUIT target.
+        # <- ABAAE SQ nefarious.midnight.vpn 0 :test
+        if split_server in (self.irc.sid, self.irc.uplink):
+            raise ProtocolError('SQUIT received: (reason: %s)' % args[-1])
+
+        affected_users = []
+        affected_nicks = defaultdict(list)
+        log.debug('(%s) Splitting server %s (reason: %s)', self.irc.name, split_server, args[-1])
+
+        if split_server not in self.irc.servers:
+            log.warning("(%s) Tried to split a server (%s) that didn't exist!", self.irc.name, split_server)
+            return
+
+        # Prevent RuntimeError: dictionary changed size during iteration
+        old_servers = self.irc.servers.copy()
+        old_channels = self.irc.channels.copy()
+
+        # Cycle through our list of servers. If any server's uplink is the one that is being SQUIT,
+        # remove them and all their users too.
+        for sid, data in old_servers.items():
+            if data.uplink == split_server:
+                log.debug('Server %s also hosts server %s, removing those users too...', split_server, sid)
+                # Recursively run SQUIT on any other hubs this server may have been connected to.
+                args = self._squit(sid, 'SQUIT', [sid, "0",
+                                   "PyLink: Automatically splitting leaf servers of %s" % sid])
+                affected_users += args['users']
+
+        for user in self.irc.servers[split_server].users.copy():
+            affected_users.append(user)
+            nick = self.irc.users[user].nick
+
+            # Nicks affected is channel specific for SQUIT:. This makes Clientbot's SQUIT relaying
+            # much easier to implement.
+            for name, cdata in old_channels.items():
+                if user in cdata.users:
+                    affected_nicks[name].append(nick)
+
+            log.debug('Removing client %s (%s)', user, nick)
+            self.removeClient(user)
+
+        serverdata = self.irc.servers[split_server]
+        sname = serverdata.name
+        uplink = serverdata.uplink
+
+        del self.irc.servers[split_server]
+        log.debug('(%s) Netsplit affected users: %s', self.irc.name, affected_users)
+
+        return {'target': split_server, 'users': affected_users, 'name': sname,
+                'uplink': uplink, 'nicks': affected_nicks, 'serverdata': serverdata,
+                'channeldata': old_channels}
+
+    @staticmethod
+    def parseCapabilities(args, fallback=''):
+        """
+        Parses a string of capabilities in the 005 / RPL_ISUPPORT format.
+        """
+
+        if type(args) == str:
+            args = args.split(' ')
+
+        caps = {}
+        for cap in args:
+            try:
+                # Try to split it as a KEY=VALUE pair.
+                key, value = cap.split('=', 1)
+            except ValueError:
+                key = cap
+                value = fallback
+            caps[key] = value
+
+        return caps
+
+    @staticmethod
+    def parsePrefixes(args):
+        """
+        Separates prefixes field like "(qaohv)~&@%+" into a dict mapping mode characters to mode
+        prefixes.
+        """
+        prefixsearch = re.search(r'\(([A-Za-z]+)\)(.*)', args)
+        return dict(zip(prefixsearch.group(1), prefixsearch.group(2)))
+
+    def handle_error(self, numeric, command, args):
+        """Handles ERROR messages - these mean that our uplink has disconnected us!"""
+        raise ProtocolError('Received an ERROR, disconnecting!')
+
+class IRCS2SProtocol(IRCCommonProtocol):
     COMMAND_TOKENS = {}
 
     def __init__(self, irc):

--- a/protocols/nefarious.py
+++ b/protocols/nefarious.py
@@ -11,6 +11,6 @@ class NefariousProtocol(P10Protocol):
         log.warning("(%s) protocols/nefarious.py has been renamed to protocols/p10.py, which "
                     "now also supports other IRCu variants. Please update your configuration, "
                     "as this migration stub will be removed in a future version.",
-                    self.irc.name)
+                    self.name)
 
 Class = NefariousProtocol

--- a/protocols/nefarious.py
+++ b/protocols/nefarious.py
@@ -6,8 +6,8 @@ from pylinkirc.log import log
 from pylinkirc.protocols.p10 import *
 
 class NefariousProtocol(P10Protocol):
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         log.warning("(%s) protocols/nefarious.py has been renamed to protocols/p10.py, which "
                     "now also supports other IRCu variants. Please update your configuration, "
                     "as this migration stub will be removed in a future version.",

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -705,7 +705,7 @@ class P10Protocol(IRCS2SProtocol):
         self.channels[target].topic = text
         self.channels[target].topicset = True
 
-    def updateClient(self, target, field, text):
+    def update_client(self, target, field, text):
         """Updates the ident or host of any connected client."""
         uobj = self.users[target]
 

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -689,7 +689,7 @@ class P10Protocol(IRCS2SProtocol):
         self.channels[target].topic = text
         self.channels[target].topicset = True
 
-    def topicBurst(self, numeric, target, text):
+    def topic_burst(self, numeric, target, text):
         """Sends a TOPIC change from a PyLink server."""
         # <- AB T #test GL!~gl@nefarious.midnight.vpn 1460852591 1460855795 :blah
 

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -1124,7 +1124,7 @@ class P10Protocol(IRCS2SProtocol):
         # <- ABAAA M GL -w
         # <- ABAAA M #test +v ABAAB 1460747615
         # <- ABAAA OM #test +h ABAAA
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         if utils.isChannel(target):
             target = self.irc.toLower(target)
 
@@ -1204,7 +1204,7 @@ class P10Protocol(IRCS2SProtocol):
         # 2 <channel>
         # - note that the target is a nickname, not a numeric.
         # <- ABAAA I PyLink-devel #services 1460948992
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         channel = self.irc.toLower(args[1])
 
         return {'target': target, 'channel': channel}

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -275,10 +275,9 @@ class P10Protocol(IRCS2SProtocol):
         realhost = realhost or host
         raw_modes = self.join_modes(modes)
 
-        # Initialize an IrcUser instance
-        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
-                                          realhost=realhost, ip=ip, manipulatable=manipulatable,
-                                          opertype=opertype)
+        # Initialize an User instance
+        u = self.users[uid] = User(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+                                   realhost=realhost, ip=ip, manipulatable=manipulatable, opertype=opertype)
 
         # Fill in modes and add it to our users index
         self.apply_modes(uid, modes)
@@ -856,7 +855,7 @@ class P10Protocol(IRCS2SProtocol):
                       'host=%s realname=%s realhost=%s ip=%s', self.name, nick, ts, uid,
                       ident, host, realname, realhost, ip)
 
-            uobj = self.users[uid] = IrcUser(nick, ts, uid, source, ident, host, realname, realhost, ip)
+            uobj = self.users[uid] = User(nick, ts, uid, source, ident, host, realname, realhost, ip)
             self.servers[source].users.add(uid)
 
             # https://github.com/evilnet/nefarious2/blob/master/doc/p10.txt#L708

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -659,7 +659,7 @@ class P10Protocol(IRCS2SProtocol):
         self._send_with_prefix(uplink, 'SERVER %s 1 %s %s P10 %s]]] +h6 :%s' % \
                    (name, self.start_ts, int(time.time()), sid, desc))
 
-        self.servers[sid] = IrcServer(uplink, name, internal=True, desc=desc)
+        self.servers[sid] = Server(uplink, name, internal=True, desc=desc)
         return sid
 
     def squit(self, source, target, text='No reason given'):
@@ -829,7 +829,7 @@ class P10Protocol(IRCS2SProtocol):
         servername = args[0].lower()
         sid = args[5][:2]
         sdesc = args[-1]
-        self.servers[sid] = IrcServer(source, servername, desc=sdesc)
+        self.servers[sid] = Server(source, servername, desc=sdesc)
 
         if self.uplink is None:
             # If we haven't already found our uplink, this is probably it.

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -749,8 +749,8 @@ class P10Protocol(IRCS2SProtocol):
 
         # P10 cloaks aren't as simple as just replacing the displayed host with the one we're
         # sending. Check for cloak changes properly.
-        # Note: we don't need to send any hooks here, check_cloak_change does that for us.
-        self.check_cloak_change(target)
+        # Note: we don't need to send any hooks here, _check_cloak_change does that for us.
+        self._check_cloak_change(target)
 
     ### HANDLERS
 
@@ -878,7 +878,7 @@ class P10Protocol(IRCS2SProtocol):
                 if ('+o', None) in parsedmodes:
                     self.callHooks([uid, 'CLIENT_OPERED', {'text': 'IRC Operator'}])
 
-            self.check_cloak_change(uid)
+            self._check_cloak_change(uid)
 
             return {'uid': uid, 'ts': ts, 'nick': nick, 'realhost': realhost, 'host': host, 'ident': ident, 'ip': ip}
 
@@ -892,13 +892,13 @@ class P10Protocol(IRCS2SProtocol):
             # Update the nick TS.
             return {'newnick': newnick, 'oldnick': oldnick, 'ts': ts}
 
-    def check_cloak_change(self, uid):
+    def _check_cloak_change(self, uid):
         """Checks for cloak changes (ident and host) on the given UID."""
         uobj = self.users[uid]
         ident = uobj.ident
 
         modes = dict(uobj.modes)
-        log.debug('(%s) check_cloak_change: modes of %s are %s', self.name, uid, modes)
+        log.debug('(%s) _check_cloak_change: modes of %s are %s', self.name, uid, modes)
 
         if 'x' not in modes:  # +x isn't set, so cloaking is disabled.
             newhost = uobj.realhost
@@ -1138,7 +1138,7 @@ class P10Protocol(IRCS2SProtocol):
 
         if target in self.users:
             # Target was a user. Check for any cloak changes.
-            self.check_cloak_change(target)
+            self._check_cloak_change(target)
 
         return {'target': target, 'modes': changedmodes}
     # OPMODE is like SAMODE on other IRCds, and it follows the same modesetting syntax.
@@ -1239,7 +1239,7 @@ class P10Protocol(IRCS2SProtocol):
         self.callHooks([target, 'CLIENT_SERVICES_LOGIN', {'text': accountname}])
 
         # Check for any cloak changes now.
-        self.check_cloak_change(target)
+        self._check_cloak_change(target)
 
     def handle_fake(self, numeric, command, args):
         """Handles incoming FAKE hostmask changes."""
@@ -1249,8 +1249,8 @@ class P10Protocol(IRCS2SProtocol):
         # Assume a usermode +f change, and then update the cloak checking.
         self.applyModes(target, [('+f', text)])
 
-        self.check_cloak_change(target)
-        # We don't need to send any hooks here, check_cloak_change does that for us.
+        self._check_cloak_change(target)
+        # We don't need to send any hooks here, _check_cloak_change does that for us.
 
     def handle_svsnick(self, source, command, args):
         """Handles SVSNICK (forced nickname change attempts)."""

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -240,7 +240,7 @@ class P10Protocol(IRCS2SProtocol):
 
     ### COMMANDS
 
-    def spawnClient(self, nick, ident='null', host='null', realhost=None, modes=set(),
+    def spawn_client(self, nick, ident='null', host='null', realhost=None, modes=set(),
             server=None, ip='0.0.0.0', realname=None, ts=None, opertype='IRC Operator',
             manipulatable=False):
         """

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -626,7 +626,7 @@ class P10Protocol(IRCS2SProtocol):
 
         self.updateTS(server, channel, ts, changedmodes)
 
-    def spawnServer(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
+    def spawn_server(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
         """
         Spawns a server off a PyLink server. desc (server description)
         defaults to the one in the config. uplink defaults to the main PyLink

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -1144,32 +1144,6 @@ class P10Protocol(IRCS2SProtocol):
     # OPMODE is like SAMODE on other IRCds, and it follows the same modesetting syntax.
     handle_opmode = handle_mode
 
-    def handle_part(self, source, command, args):
-        """Handles user parts."""
-        # <- ABAAA L #test,#test2
-        # <- ABAAA L #test :test
-
-        channels = self.toLower(args[0]).split(',')
-        for channel in channels:
-            # We should only get PART commands for channels that exist, right??
-            self.channels[channel].removeuser(source)
-
-            try:
-                self.users[source].channels.discard(channel)
-            except KeyError:
-                log.debug("(%s) handle_part: KeyError trying to remove %r from %r's channel list?",
-                          self.name, channel, source)
-            try:
-                reason = args[1]
-            except IndexError:
-                reason = ''
-
-            # Clear empty non-permanent channels.
-            if not self.channels[channel].users:
-                del self.channels[channel]
-
-        return {'channels': channels, 'text': reason}
-
     def handle_kick(self, source, command, args):
         """Handles incoming KICKs."""
         # <- ABAAA K #TEST AyAAA :PyLink-devel

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -586,7 +586,7 @@ class P10Protocol(IRCS2SProtocol):
                     if linenum:  # Implies "if linenum > 0"
                         # XXX: Ugh, this postprocessing sucks, but we have to make sure that mode prefixes are accounted
                         # for in the burst.
-                        wrapped_args = self.parseArgs(wrapped_msg.split(" "))
+                        wrapped_args = self.parse_args(wrapped_msg.split(" "))
                         wrapped_namelist = wrapped_args[-1].split(',')
                         log.debug('(%s) sjoin: wrapped args: %s (post-wrap fixing)', self.name,
                                   wrapped_args)

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -1171,18 +1171,6 @@ class P10Protocol(IRCS2SProtocol):
         return {'channel': channel, 'setter': args[1], 'text': topic,
                 'oldtopic': oldtopic}
 
-    def handle_invite(self, source, command, args):
-        """Handles incoming INVITEs."""
-        # From P10 docs:
-        # 1 <target nick>
-        # 2 <channel>
-        # - note that the target is a nickname, not a numeric.
-        # <- ABAAA I PyLink-devel #services 1460948992
-        target = self._get_UID(args[0])
-        channel = self.toLower(args[1])
-
-        return {'target': target, 'channel': channel}
-
     def handle_clearmode(self, numeric, command, args):
         """Handles CLEARMODE, which is used to clear a channel's modes."""
         # <- ABAAA CM #test ovpsmikbl

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -374,7 +374,7 @@ class P10Protocol(IRCS2SProtocol):
             raise LookupError('No such PyLink client/server exists.')
 
         self._send_with_prefix(numeric, 'D %s :Killed (%s)' % (target, reason))
-        self.removeClient(target)
+        self._remove_client(target)
 
     def knock(self, numeric, target, text):
         raise NotImplementedError('KNOCK is not supported on P10.')
@@ -487,7 +487,7 @@ class P10Protocol(IRCS2SProtocol):
         """Quits a PyLink client."""
         if self.isInternalClient(numeric):
             self._send_with_prefix(numeric, "Q :%s" % reason)
-            self.removeClient(numeric)
+            self._remove_client(numeric)
         else:
             raise LookupError("No such PyLink client exists.")
 

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -151,14 +151,14 @@ class P10Protocol(IRCS2SProtocol):
         'FA': 'FAKE'
     }
 
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # Dictionary of UID generators (one for each server).
         self.uidgen = structures.KeyedDefaultdict(P10UIDGenerator)
 
         # SID generator for P10.
-        self.sidgen = P10SIDGenerator(irc)
+        self.sidgen = P10SIDGenerator(self)
 
         self.hook_map = {'END_OF_BURST': 'ENDBURST', 'OPMODE': 'MODE', 'CLEARMODE': 'MODE', 'BURST': 'JOIN'}
 
@@ -754,7 +754,7 @@ class P10Protocol(IRCS2SProtocol):
 
     ### HANDLERS
 
-    def connect(self):
+    def post_connect(self):
         """Initializes a connection to a server."""
         ts = self.irc.start_ts
 

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -966,7 +966,7 @@ class P10Protocol(IRCS2SProtocol):
         # Why is this the way it is? I don't know... -GL
 
         target = args[1]
-        sid = self._getSid(target)
+        sid = self._get_SID(target)
         orig_pingtime = args[0][1:]  # Strip the !, used to denote a TS instead of a server name.
 
         currtime = time.time()

--- a/protocols/ratbox.py
+++ b/protocols/ratbox.py
@@ -19,7 +19,7 @@ class RatboxProtocol(TS6Protocol):
         """Initializes a connection to a server."""
 
         # Note: +r, +e, and +I support will be negotiated on link
-        self.irc.cmodes = {'op': 'o', 'secret': 's', 'private': 'p', 'noextmsg': 'n', 'moderated': 'm',
+        self.cmodes = {'op': 'o', 'secret': 's', 'private': 'p', 'noextmsg': 'n', 'moderated': 'm',
                        'inviteonly': 'i', 'topiclock': 't', 'limit': 'l', 'ban': 'b', 'voice': 'v',
                        'key': 'k', 'sslonly': 'S',
                        '*A': 'beI',
@@ -27,7 +27,7 @@ class RatboxProtocol(TS6Protocol):
                        '*C': 'l',
                        '*D': 'imnpstrS'}
 
-        self.irc.umodes = {
+        self.umodes = {
             'invisible': 'i', 'callerid': 'g', 'oper': 'o', 'admin': 'a', 'sno_botfloods': 'b',
             'sno_clientconnections': 'c', 'sno_extclientconnections': 'C', 'sno_debug': 'd',
             'sno_fullauthblock': 'f', 'sno_skill': 'k', 'locops': 'l',
@@ -51,23 +51,23 @@ class RatboxProtocol(TS6Protocol):
         # parameters: nickname, hopcount, nickTS, umodes, username, visible hostname, IP address,
         # UID, gecos
 
-        server = server or self.irc.sid
-        if not self.irc.isInternalServer(server):
+        server = server or self.sid
+        if not self.isInternalServer(server):
             raise ValueError('Server %r is not a PyLink server!' % server)
 
         uid = self.uidgen[server].next_uid()
 
         ts = ts or int(time.time())
         realname = realname or conf.conf['bot']['realname']
-        raw_modes = self.irc.joinModes(modes)
+        raw_modes = self.joinModes(modes)
 
         orig_realhost = realhost
         realhost = realhost or host
 
-        u = self.irc.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable)
-        self.irc.applyModes(uid, modes)
-        self.irc.servers[server].users.add(uid)
+        self.applyModes(uid, modes)
+        self.servers[server].users.add(uid)
         self._send(server, "UID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "
                    ":{realname}".format(ts=ts, host=host,
                     nick=nick, ident=ident, uid=uid,
@@ -86,11 +86,11 @@ class RatboxProtocol(TS6Protocol):
     def handle_realhost(self, uid, command, args):
         """Handles real host propagation."""
         log.debug('(%s) Got REALHOST %s for %s', args[0], uid)
-        self.irc.users[uid].realhost = args[0]
+        self.users[uid].realhost = args[0]
 
     def handle_login(self, uid, command, args):
         """Handles login propagation on burst."""
-        self.irc.users[uid].services_account = args[0]
+        self.users[uid].services_account = args[0]
         return {'text': args[0]}
 
 Class = RatboxProtocol

--- a/protocols/ratbox.py
+++ b/protocols/ratbox.py
@@ -18,6 +18,8 @@ class RatboxProtocol(TS6Protocol):
     def post_connect(self):
         """Initializes a connection to a server."""
 
+        super().post_connect()
+
         # Note: +r, +e, and +I support will be negotiated on link
         self.cmodes = {'op': 'o', 'secret': 's', 'private': 'p', 'noextmsg': 'n', 'moderated': 'm',
                        'inviteonly': 'i', 'topiclock': 't', 'limit': 'l', 'ban': 'b', 'voice': 'v',
@@ -68,14 +70,15 @@ class RatboxProtocol(TS6Protocol):
             realhost=realhost, ip=ip, manipulatable=manipulatable)
         self.applyModes(uid, modes)
         self.servers[server].users.add(uid)
-        self._send(server, "UID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "
-                   ":{realname}".format(ts=ts, host=host,
-                    nick=nick, ident=ident, uid=uid,
-                   modes=raw_modes, ip=ip, realname=realname))
+
+        self._send_with_prefix(server, "UID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "
+                               ":{realname}".format(ts=ts, host=host,
+                               nick=nick, ident=ident, uid=uid,
+                               modes=raw_modes, ip=ip, realname=realname))
 
         if orig_realhost:
             # If real host is specified, send it using ENCAP REALHOST
-            self._send(uid, "ENCAP * REALHOST %s" % orig_realhost)
+            self._send_with_prefix(uid, "ENCAP * REALHOST %s" % orig_realhost)
 
         return u
 

--- a/protocols/ratbox.py
+++ b/protocols/ratbox.py
@@ -66,7 +66,7 @@ class RatboxProtocol(TS6Protocol):
         orig_realhost = realhost
         realhost = realhost or host
 
-        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        u = self.users[uid] = User(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable)
         self.apply_modes(uid, modes)
         self.servers[server].users.add(uid)

--- a/protocols/ratbox.py
+++ b/protocols/ratbox.py
@@ -40,7 +40,7 @@ class RatboxProtocol(TS6Protocol):
             '*A': '', '*B': '', '*C': '', '*D': 'igoabcCdfklrsuwxyzZD'
         }
 
-    def spawnClient(self, nick, ident='null', host='null', realhost=None, modes=set(),
+    def spawn_client(self, nick, ident='null', host='null', realhost=None, modes=set(),
             server=None, ip='0.0.0.0', realname=None, ts=None, opertype=None,
             manipulatable=False):
         """

--- a/protocols/ratbox.py
+++ b/protocols/ratbox.py
@@ -82,8 +82,8 @@ class RatboxProtocol(TS6Protocol):
 
         return u
 
-    def updateClient(self, target, field, text):
-        """updateClient() stub for ratbox."""
+    def update_client(self, target, field, text):
+        """update_client() stub for ratbox."""
         raise NotImplementedError("User data changing is not supported on ircd-ratbox.")
 
     def handle_realhost(self, uid, command, args):

--- a/protocols/ratbox.py
+++ b/protocols/ratbox.py
@@ -7,17 +7,16 @@ from pylinkirc.protocols.ts6 import *
 
 class RatboxProtocol(TS6Protocol):
 
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # Don't require EUID for Ratbox
         self.required_caps.discard('EUID')
 
         self.hook_map['LOGIN'] = 'CLIENT_SERVICES_LOGIN'
         self.protocol_caps -= {'slash-in-hosts'}
 
-    def connect(self):
+    def post_connect(self):
         """Initializes a connection to a server."""
-        super().connect()
 
         # Note: +r, +e, and +I support will be negotiated on link
         self.irc.cmodes = {'op': 'o', 'secret': 's', 'private': 'p', 'noextmsg': 'n', 'moderated': 'm',

--- a/protocols/ratbox.py
+++ b/protocols/ratbox.py
@@ -54,21 +54,21 @@ class RatboxProtocol(TS6Protocol):
         # UID, gecos
 
         server = server or self.sid
-        if not self.isInternalServer(server):
+        if not self.is_internal_server(server):
             raise ValueError('Server %r is not a PyLink server!' % server)
 
         uid = self.uidgen[server].next_uid()
 
         ts = ts or int(time.time())
         realname = realname or conf.conf['bot']['realname']
-        raw_modes = self.joinModes(modes)
+        raw_modes = self.join_modes(modes)
 
         orig_realhost = realhost
         realhost = realhost or host
 
         u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable)
-        self.applyModes(uid, modes)
+        self.apply_modes(uid, modes)
         self.servers[server].users.add(uid)
 
         self._send_with_prefix(server, "UID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -646,7 +646,7 @@ class TS6Protocol(TS6BaseProtocol):
 
     def handle_chghost(self, numeric, command, args):
         """Handles incoming CHGHOST commands."""
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         self.irc.users[target].host = newhost = args[1]
         return {'target': target, 'newhost': newhost}
 

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -27,7 +27,7 @@ class TS6Protocol(TS6BaseProtocol):
 
     ### OUTGOING COMMANDS
 
-    def spawnClient(self, nick, ident='null', host='null', realhost=None, modes=set(),
+    def spawn_client(self, nick, ident='null', host='null', realhost=None, modes=set(),
             server=None, ip='0.0.0.0', realname=None, ts=None, opertype='IRC Operator',
             manipulatable=False):
         """

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -364,7 +364,7 @@ class TS6Protocol(TS6BaseProtocol):
 
         # Server name and SID are sent in different messages, so we fill this
         # with dummy information until we get the actual sid.
-        self.servers[numeric] = IrcServer(None, '')
+        self.servers[numeric] = Server(None, '')
         self.uplink = numeric
 
     def handle_capab(self, numeric, command, args):
@@ -555,7 +555,7 @@ class TS6Protocol(TS6BaseProtocol):
         servername = args[0].lower()
         sid = args[2]
         sdesc = args[-1]
-        self.servers[sid] = IrcServer(numeric, servername, desc=sdesc)
+        self.servers[sid] = Server(numeric, servername, desc=sdesc)
         return {'name': servername, 'sid': sid, 'text': sdesc}
 
     def handle_server(self, numeric, command, args):
@@ -580,7 +580,7 @@ class TS6Protocol(TS6BaseProtocol):
         # <- :services.int SERVER a.bc 2 :(H) [GL] a
         servername = args[0].lower()
         sdesc = args[-1]
-        self.servers[servername] = IrcServer(numeric, servername, desc=sdesc)
+        self.servers[servername] = Server(numeric, servername, desc=sdesc)
         return {'name': servername, 'sid': None, 'text': sdesc}
 
     def handle_tmode(self, numeric, command, args):

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -195,7 +195,7 @@ class TS6Protocol(TS6BaseProtocol):
             joinedmodes = self.join_modes(modes)
             self._send_with_prefix(numeric, 'MODE %s %s' % (target, joinedmodes))
 
-    def topicBurst(self, numeric, target, text):
+    def topic_burst(self, numeric, target, text):
         """Sends a topic change from a PyLink server. This is usually used on burst."""
         if not self.is_internal_server(numeric):
             raise LookupError('No such PyLink server exists.')
@@ -330,7 +330,7 @@ class TS6Protocol(TS6BaseProtocol):
         # KNOCK: support for /knock
         # SAVE: support for SAVE (forces user to UID in nick collision)
         # SERVICES: adds mode +r (only registered users can join a channel)
-        # TB: topic burst command; we send this in topicBurst
+        # TB: topic burst command; we send this in topic_burst
         # EUID: extended UID command, which includes real hostname + account data info,
         #       and allows sending CHGHOST without ENCAP.
         # RSFNC: states that we support RSFNC (forced nick changed attempts). XXX: With atheme services,

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -227,7 +227,7 @@ class TS6Protocol(TS6BaseProtocol):
         # No text value is supported here; drop it.
         self._send_with_prefix(numeric, 'KNOCK %s' % target)
 
-    def updateClient(self, target, field, text):
+    def update_client(self, target, field, text):
         """Updates the hostname of any connected client."""
         field = field.upper()
         if field == 'HOST':

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -638,7 +638,7 @@ class TS6Protocol(TS6BaseProtocol):
         target = args[0]
         channel = self.toLower(args[1])
         try:
-            ts = args[3]
+            ts = args[2]
         except IndexError:
             ts = int(time.time())
         # We don't actually need to process this; it's just something plugins/hooks can use

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -632,18 +632,6 @@ class TS6Protocol(TS6BaseProtocol):
         self.channels[channel].topicset = True
         return {'channel': channel, 'setter': setter, 'ts': ts, 'text': topic}
 
-    def handle_invite(self, numeric, command, args):
-        """Handles incoming INVITEs."""
-        # <- :70MAAAAAC INVITE 0ALAAAAAA #blah 12345
-        target = args[0]
-        channel = self.toLower(args[1])
-        try:
-            ts = args[2]
-        except IndexError:
-            ts = int(time.time())
-        # We don't actually need to process this; it's just something plugins/hooks can use
-        return {'target': target, 'channel': channel, 'ts': ts}
-
     def handle_chghost(self, numeric, command, args):
         """Handles incoming CHGHOST commands."""
         target = self._get_UID(args[0])

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -13,8 +13,8 @@ from pylinkirc.protocols.ts6_common import *
 S2S_BUFSIZE = 510
 
 class TS6Protocol(TS6BaseProtocol):
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.protocol_caps |= {'slash-in-hosts'}
         self.casemapping = 'rfc1459'
         self.hook_map = {'SJOIN': 'JOIN', 'TB': 'TOPIC', 'TMODE': 'MODE', 'BMASK': 'MODE',
@@ -255,7 +255,7 @@ class TS6Protocol(TS6BaseProtocol):
 
     ### Core / handlers
 
-    def connect(self):
+    def post_connect(self):
         """Initializes a connection to a server."""
         ts = self.irc.start_ts
         self.has_eob = False

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -50,7 +50,7 @@ class TS6Protocol(TS6BaseProtocol):
         realname = realname or conf.conf['bot']['realname']
         realhost = realhost or host
         raw_modes = self.join_modes(modes)
-        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        u = self.users[uid] = User(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable, opertype=opertype)
 
         self.apply_modes(uid, modes)
@@ -512,7 +512,7 @@ class TS6Protocol(TS6BaseProtocol):
         if ip == '0':  # IP was invalid; something used for services.
             ip = '0.0.0.0'
 
-        self.users[uid] = IrcUser(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
+        self.users[uid] = User(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
 
         parsedmodes = self.parse_modes(uid, [modes])
         log.debug('Applying modes %s for %s', parsedmodes, uid)

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -36,9 +36,9 @@ class TS6Protocol(TS6BaseProtocol):
         Note: No nick collision / valid nickname checks are done here; it is
         up to plugins to make sure they don't introduce anything invalid.
         """
-        server = server or self.irc.sid
+        server = server or self.sid
 
-        if not self.irc.isInternalServer(server):
+        if not self.isInternalServer(server):
             raise ValueError('Server %r is not a PyLink server!' % server)
 
         uid = self.uidgen[server].next_uid()
@@ -49,12 +49,12 @@ class TS6Protocol(TS6BaseProtocol):
         ts = ts or int(time.time())
         realname = realname or conf.conf['bot']['realname']
         realhost = realhost or host
-        raw_modes = self.irc.joinModes(modes)
-        u = self.irc.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        raw_modes = self.joinModes(modes)
+        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable, opertype=opertype)
 
-        self.irc.applyModes(uid, modes)
-        self.irc.servers[server].users.add(uid)
+        self.applyModes(uid, modes)
+        self.servers[server].users.add(uid)
 
         self._send_with_prefix(server, "EUID {nick} 1 {ts} {modes} {ident} {host} {ip} {uid} "
                 "{realhost} * :{realname}".format(ts=ts, host=host,
@@ -66,15 +66,15 @@ class TS6Protocol(TS6BaseProtocol):
 
     def join(self, client, channel):
         """Joins a PyLink client to a channel."""
-        channel = self.irc.toLower(channel)
+        channel = self.toLower(channel)
         # JOIN:
         # parameters: channelTS, channel, '+' (a plus sign)
-        if not self.irc.isInternalClient(client):
-            log.error('(%s) Error trying to join %r to %r (no such client exists)', self.irc.name, client, channel)
+        if not self.isInternalClient(client):
+            log.error('(%s) Error trying to join %r to %r (no such client exists)', self.name, client, channel)
             raise LookupError('No such PyLink client exists.')
-        self._send_with_prefix(client, "JOIN {ts} {channel} +".format(ts=self.irc.channels[channel].ts, channel=channel))
-        self.irc.channels[channel].users.add(client)
-        self.irc.users[client].channels.add(channel)
+        self._send_with_prefix(client, "JOIN {ts} {channel} +".format(ts=self.channels[channel].ts, channel=channel))
+        self.channels[channel].users.add(client)
+        self.users[client].channels.add(channel)
 
     def sjoin(self, server, channel, users, ts=None, modes=set()):
         """Sends an SJOIN for a group of users to a channel.
@@ -85,7 +85,7 @@ class TS6Protocol(TS6BaseProtocol):
 
         Example uses:
             sjoin('100', '#test', [('', '100AAABBC'), ('o', 100AAABBB'), ('v', '100AAADDD')])
-            sjoin(self.irc.sid, '#test', [('o', self.irc.pseudoclient.uid)])
+            sjoin(self.sid, '#test', [('o', self.pseudoclient.uid)])
         """
         # https://github.com/grawity/irc-docs/blob/master/server/ts6.txt#L821
         # parameters: channelTS, channel, simple modes, opt. mode parameters..., nicklist
@@ -96,34 +96,34 @@ class TS6Protocol(TS6BaseProtocol):
         # their status ('@+', '@', '+' or ''), for example:
         # '@+1JJAAAAAB +2JJAAAA4C 1JJAAAADS'. All users must be behind the source server
         # so it is not possible to use this message to force users to join a channel.
-        channel = self.irc.toLower(channel)
-        server = server or self.irc.sid
+        channel = self.toLower(channel)
+        server = server or self.sid
         assert users, "sjoin: No users sent?"
-        log.debug('(%s) sjoin: got %r for users', self.irc.name, users)
+        log.debug('(%s) sjoin: got %r for users', self.name, users)
         if not server:
             raise LookupError('No such PyLink client exists.')
 
-        modes = set(modes or self.irc.channels[channel].modes)
-        orig_ts = self.irc.channels[channel].ts
+        modes = set(modes or self.channels[channel].modes)
+        orig_ts = self.channels[channel].ts
         ts = ts or orig_ts
 
         # Get all the ban modes in a separate list. These are bursted using a separate BMASK
         # command.
-        banmodes = {k: [] for k in self.irc.cmodes['*A']}
+        banmodes = {k: [] for k in self.cmodes['*A']}
         regularmodes = []
-        log.debug('(%s) Unfiltered SJOIN modes: %s', self.irc.name, modes)
+        log.debug('(%s) Unfiltered SJOIN modes: %s', self.name, modes)
         for mode in modes:
             modechar = mode[0][-1]
-            if modechar in self.irc.cmodes['*A']:
+            if modechar in self.cmodes['*A']:
                 # Mode character is one of 'beIq'
-                if (modechar, mode[1]) in self.irc.channels[channel].modes:
+                if (modechar, mode[1]) in self.channels[channel].modes:
                     # Don't reset modes that are already set.
                     continue
 
                 banmodes[modechar].append(mode[1])
             else:
                 regularmodes.append(mode)
-        log.debug('(%s) Filtered SJOIN modes to be regular modes: %s, banmodes: %s', self.irc.name, regularmodes, banmodes)
+        log.debug('(%s) Filtered SJOIN modes to be regular modes: %s, banmodes: %s', self.name, regularmodes, banmodes)
 
         changedmodes = modes
         while users[:12]:
@@ -135,22 +135,22 @@ class TS6Protocol(TS6BaseProtocol):
                 prefixes, user = userpair
                 prefixchars = ''
                 for prefix in prefixes:
-                    pr = self.irc.prefixmodes.get(prefix)
+                    pr = self.prefixmodes.get(prefix)
                     if pr:
                         prefixchars += pr
                         changedmodes.add(('+%s' % prefix, user))
                 namelist.append(prefixchars+user)
                 uids.append(user)
                 try:
-                    self.irc.users[user].channels.add(channel)
+                    self.users[user].channels.add(channel)
                 except KeyError:  # Not initialized yet?
-                    log.debug("(%s) sjoin: KeyError trying to add %r to %r's channel list?", self.irc.name, channel, user)
+                    log.debug("(%s) sjoin: KeyError trying to add %r to %r's channel list?", self.name, channel, user)
             users = users[12:]
             namelist = ' '.join(namelist)
             self._send_with_prefix(server, "SJOIN {ts} {channel} {modes} :{users}".format(
                     ts=ts, users=namelist, channel=channel,
-                    modes=self.irc.joinModes(regularmodes)))
-            self.irc.channels[channel].users.update(uids)
+                    modes=self.joinModes(regularmodes)))
+            self.channels[channel].users.update(uids)
 
         # Now, burst bans.
         # <- :42X BMASK 1424222769 #dev b :*!test@*.isp.net *!badident@*
@@ -158,12 +158,12 @@ class TS6Protocol(TS6BaseProtocol):
             # Max 15-3 = 12 bans per line to prevent cut off. (TS6 allows a max of 15 parameters per
             # line)
             if bans:
-                log.debug('(%s) sjoin: bursting mode %s with bans %s, ts:%s', self.irc.name, bmode, bans, ts)
+                log.debug('(%s) sjoin: bursting mode %s with bans %s, ts:%s', self.name, bmode, bans, ts)
                 msgprefix = ':{sid} BMASK {ts} {channel} {bmode} :'.format(sid=server, ts=ts,
                                                                           channel=channel, bmode=bmode)
                 # Actually, we cut off at 17 arguments/line, since the prefix and command name don't count.
                 for msg in utils.wrapArguments(msgprefix, bans, S2S_BUFSIZE, max_args_per_line=17):
-                    self.irc.send(msg)
+                    self.send(msg)
 
         self.updateTS(server, channel, ts, changedmodes)
 
@@ -172,15 +172,15 @@ class TS6Protocol(TS6BaseProtocol):
         # c <- :0UYAAAAAA TMODE 0 #a +o 0T4AAAAAC
         # u <- :0UYAAAAAA MODE 0UYAAAAAA :-Facdefklnou
 
-        if (not self.irc.isInternalClient(numeric)) and \
-                (not self.irc.isInternalServer(numeric)):
+        if (not self.isInternalClient(numeric)) and \
+                (not self.isInternalServer(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
-        self.irc.applyModes(target, modes)
+        self.applyModes(target, modes)
         modes = list(modes)
 
         if utils.isChannel(target):
-            ts = ts or self.irc.channels[self.irc.toLower(target)].ts
+            ts = ts or self.channels[self.toLower(target)].ts
             # TMODE:
             # parameters: channelTS, channel, cmode changes, opt. cmode parameters...
 
@@ -189,40 +189,40 @@ class TS6Protocol(TS6BaseProtocol):
             msgprefix = ':%s TMODE %s %s ' % (numeric, ts, target)
             bufsize = S2S_BUFSIZE - len(msgprefix)
 
-            for modestr in self.irc.wrapModes(modes, bufsize, max_modes_per_msg=10):
-                self.irc.send(msgprefix + modestr)
+            for modestr in self.wrapModes(modes, bufsize, max_modes_per_msg=10):
+                self.send(msgprefix + modestr)
         else:
-            joinedmodes = self.irc.joinModes(modes)
+            joinedmodes = self.joinModes(modes)
             self._send_with_prefix(numeric, 'MODE %s %s' % (target, joinedmodes))
 
     def topicBurst(self, numeric, target, text):
         """Sends a topic change from a PyLink server. This is usually used on burst."""
-        if not self.irc.isInternalServer(numeric):
+        if not self.isInternalServer(numeric):
             raise LookupError('No such PyLink server exists.')
         # TB
         # capab: TB
         # source: server
         # propagation: broadcast
         # parameters: channel, topicTS, opt. topic setter, topic
-        ts = self.irc.channels[target].ts
-        servername = self.irc.servers[numeric].name
+        ts = self.channels[target].ts
+        servername = self.servers[numeric].name
         self._send_with_prefix(numeric, 'TB %s %s %s :%s' % (target, ts, servername, text))
-        self.irc.channels[target].topic = text
-        self.irc.channels[target].topicset = True
+        self.channels[target].topic = text
+        self.channels[target].topicset = True
 
     def invite(self, numeric, target, channel):
         """Sends an INVITE from a PyLink client.."""
-        if not self.irc.isInternalClient(numeric):
+        if not self.isInternalClient(numeric):
             raise LookupError('No such PyLink client exists.')
-        self._send_with_prefix(numeric, 'INVITE %s %s %s' % (target, channel, self.irc.channels[channel].ts))
+        self._send_with_prefix(numeric, 'INVITE %s %s %s' % (target, channel, self.channels[channel].ts))
 
     def knock(self, numeric, target, text):
         """Sends a KNOCK from a PyLink client."""
-        if 'KNOCK' not in self.irc.caps:
+        if 'KNOCK' not in self.caps:
             log.debug('(%s) knock: Dropping KNOCK to %r since the IRCd '
-                      'doesn\'t support it.', self.irc.name, target)
+                      'doesn\'t support it.', self.name, target)
             return
-        if not self.irc.isInternalClient(numeric):
+        if not self.isInternalClient(numeric):
             raise LookupError('No such PyLink client exists.')
         # No text value is supported here; drop it.
         self._send_with_prefix(numeric, 'KNOCK %s' % target)
@@ -231,12 +231,12 @@ class TS6Protocol(TS6BaseProtocol):
         """Updates the hostname of any connected client."""
         field = field.upper()
         if field == 'HOST':
-            self.irc.users[target].host = text
-            self._send_with_prefix(self.irc.sid, 'CHGHOST %s :%s' % (target, text))
-            if not self.irc.isInternalClient(target):
+            self.users[target].host = text
+            self._send_with_prefix(self.sid, 'CHGHOST %s :%s' % (target, text))
+            if not self.isInternalClient(target):
                 # If the target isn't one of our clients, send hook payload
                 # for other plugins to listen to.
-                self.irc.callHooks([self.irc.sid, 'CHGHOST',
+                self.callHooks([self.sid, 'CHGHOST',
                                    {'target': target, 'newhost': text}])
         else:
             raise NotImplementedError("Changing field %r of a client is "
@@ -245,7 +245,7 @@ class TS6Protocol(TS6BaseProtocol):
     def ping(self, source=None, target=None):
         """Sends a PING to a target server. Periodic PINGs are sent to our uplink
         automatically by the Irc() internals; plugins shouldn't have to use this."""
-        source = source or self.irc.sid
+        source = source or self.sid
         if source is None:
             return
         if target is not None:
@@ -257,10 +257,10 @@ class TS6Protocol(TS6BaseProtocol):
 
     def post_connect(self):
         """Initializes a connection to a server."""
-        ts = self.irc.start_ts
+        ts = self.start_ts
         self.has_eob = False
 
-        f = self.irc.send
+        f = self.send
 
         # https://github.com/grawity/irc-docs/blob/master/server/ts6.txt#L80
         chary_cmodes = { # TS6 generic modes (note that +p is noknock instead of private):
@@ -278,17 +278,17 @@ class TS6Protocol(TS6BaseProtocol):
                          # Now, map all the ABCD type modes:
                         '*A': 'beIq', '*B': 'k', '*C': 'lfj', '*D': 'mnprstFLPQcgzCOAST'}
 
-        if self.irc.serverdata.get('use_owner'):
+        if self.serverdata.get('use_owner'):
             chary_cmodes['owner'] = 'y'
-            self.irc.prefixmodes['y'] = '~'
-        if self.irc.serverdata.get('use_admin'):
+            self.prefixmodes['y'] = '~'
+        if self.serverdata.get('use_admin'):
             chary_cmodes['admin'] = 'a'
-            self.irc.prefixmodes['a'] = '!'
-        if self.irc.serverdata.get('use_halfop'):
+            self.prefixmodes['a'] = '!'
+        if self.serverdata.get('use_halfop'):
             chary_cmodes['halfop'] = 'h'
-            self.irc.prefixmodes['h'] = '%'
+            self.prefixmodes['h'] = '%'
 
-        self.irc.cmodes = chary_cmodes
+        self.cmodes = chary_cmodes
 
         # Define supported user modes
         chary_umodes = {'deaf': 'D', 'servprotect': 'S', 'admin': 'a',
@@ -298,26 +298,26 @@ class TS6Protocol(TS6BaseProtocol):
                         'cloak': 'x', 'override': 'p',
                         # Now, map all the ABCD type modes:
                         '*A': '', '*B': '', '*C': '', '*D': 'DSaiowsQRgzlxp'}
-        self.irc.umodes = chary_umodes
+        self.umodes = chary_umodes
 
         # Toggles support of shadowircd/elemental-ircd specific channel modes:
         # +T (no notice), +u (hidden ban list), +E (no kicks), +J (blocks kickrejoin),
         # +K (no repeat messages), +d (no nick changes), and user modes:
         # +B (bot), +C (blocks CTCP), +D (deaf), +V (no invites), +I (hides channel list)
-        if self.irc.serverdata.get('use_elemental_modes'):
+        if self.serverdata.get('use_elemental_modes'):
             elemental_cmodes = {'hiddenbans': 'u', 'nokick': 'E',
                                 'kicknorejoin': 'J', 'repeat': 'K', 'nonick': 'd',
                                 'blockcaps': 'G'}
-            self.irc.cmodes.update(elemental_cmodes)
-            self.irc.cmodes['*D'] += ''.join(elemental_cmodes.values())
+            self.cmodes.update(elemental_cmodes)
+            self.cmodes['*D'] += ''.join(elemental_cmodes.values())
 
             elemental_umodes = {'noctcp': 'C', 'deaf': 'D', 'bot': 'B', 'noinvite': 'V',
                                 'hidechans': 'I'}
-            self.irc.umodes.update(elemental_umodes)
-            self.irc.umodes['*D'] += ''.join(elemental_umodes.values())
+            self.umodes.update(elemental_umodes)
+            self.umodes['*D'] += ''.join(elemental_umodes.values())
 
         # https://github.com/grawity/irc-docs/blob/master/server/ts6.txt#L55
-        f('PASS %s TS 6 %s' % (self.irc.serverdata["sendpass"], self.irc.sid))
+        f('PASS %s TS 6 %s' % (self.serverdata["sendpass"], self.sid))
 
         # We request the following capabilities (for charybdis):
 
@@ -338,8 +338,8 @@ class TS6Protocol(TS6BaseProtocol):
         # EOPMOD: supports ETB (extended TOPIC burst) and =#channel messages for opmoderated +z
         f('CAPAB :QS ENCAP EX CHW IE KNOCK SAVE SERVICES TB EUID RSFNC EOPMOD SAVETS_100')
 
-        f('SERVER %s 0 :%s' % (self.irc.serverdata["hostname"],
-                               self.irc.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']))
+        f('SERVER %s 0 :%s' % (self.serverdata["hostname"],
+                               self.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']))
 
         # Finally, end all the initialization with a PING - that's Charybdis'
         # way of saying end-of-burst :)
@@ -352,7 +352,7 @@ class TS6Protocol(TS6BaseProtocol):
         """
         # <- PASS $somepassword TS 6 :42X
 
-        if args[0] != self.irc.serverdata['recvpass']:
+        if args[0] != self.serverdata['recvpass']:
             # Check if recvpass is correct
             raise ProtocolError('Recvpass from uplink server %s does not match configuration!' % servername)
 
@@ -360,12 +360,12 @@ class TS6Protocol(TS6BaseProtocol):
             raise ProtocolError("Remote protocol version is too old! Is this even TS6?")
 
         numeric = args[-1]
-        log.debug('(%s) Found uplink SID as %r', self.irc.name, numeric)
+        log.debug('(%s) Found uplink SID as %r', self.name, numeric)
 
         # Server name and SID are sent in different messages, so we fill this
         # with dummy information until we get the actual sid.
-        self.irc.servers[numeric] = IrcServer(None, '')
-        self.irc.uplink = numeric
+        self.servers[numeric] = IrcServer(None, '')
+        self.uplink = numeric
 
     def handle_capab(self, numeric, command, args):
         """
@@ -374,21 +374,21 @@ class TS6Protocol(TS6BaseProtocol):
         # We only get a list of keywords here. Charybdis obviously assumes that
         # we know what modes it supports (indeed, this is a standard list).
         # <- CAPAB :BAN CHW CLUSTER ENCAP EOPMOD EUID EX IE KLN KNOCK MLOCK QS RSFNC SAVE SERVICES TB UNKLN
-        self.irc.caps = caps = args[0].split()
+        self.caps = caps = args[0].split()
 
         for required_cap in self.required_caps:
             if required_cap not in caps:
                 raise ProtocolError('%s not found in TS6 capabilities list; this is required! (got %r)' % (required_cap, caps))
 
         if 'EX' in caps:
-            self.irc.cmodes['banexception'] = 'e'
+            self.cmodes['banexception'] = 'e'
         if 'IE' in caps:
-            self.irc.cmodes['invex'] = 'I'
+            self.cmodes['invex'] = 'I'
         if 'SERVICES' in caps:
-            self.irc.cmodes['regonly'] = 'r'
+            self.cmodes['regonly'] = 'r'
 
-        log.debug('(%s) self.irc.connected set!', self.irc.name)
-        self.irc.connected.set()
+        log.debug('(%s) self.connected set!', self.name)
+        self.connected.set()
 
     def handle_ping(self, source, command, args):
         """Handles incoming PING commands."""
@@ -405,11 +405,11 @@ class TS6Protocol(TS6BaseProtocol):
         try:
             destination = args[1]
         except IndexError:
-            destination = self.irc.sid
-        if self.irc.isInternalServer(destination):
+            destination = self.sid
+        if self.isInternalServer(destination):
             self._send_with_prefix(destination, 'PONG %s %s' % (destination, source), queue=False)
 
-            if destination == self.irc.sid and not self.has_eob:
+            if destination == self.sid and not self.has_eob:
                 # Charybdis' idea of endburst is just sending a PING. No, really!
                 # https://github.com/charybdis-ircd/charybdis/blob/dc336d1/modules/core/m_server.c#L484-L485
                 self.has_eob = True
@@ -421,18 +421,18 @@ class TS6Protocol(TS6BaseProtocol):
         """Handles incoming SJOIN commands."""
         # parameters: channelTS, channel, simple modes, opt. mode parameters..., nicklist
         # <- :0UY SJOIN 1451041566 #channel +nt :@0UYAAAAAB
-        channel = self.irc.toLower(args[1])
-        chandata = self.irc.channels[channel].deepcopy()
+        channel = self.toLower(args[1])
+        chandata = self.channels[channel].deepcopy()
         userlist = args[-1].split()
 
         modestring = args[2:-1] or args[2]
-        parsedmodes = self.irc.parseModes(channel, modestring)
+        parsedmodes = self.parseModes(channel, modestring)
         namelist = []
 
         # Keep track of other modes that are added due to prefix modes being joined too.
         changedmodes = set(parsedmodes)
 
-        log.debug('(%s) handle_sjoin: got userlist %r for %r', self.irc.name, userlist, channel)
+        log.debug('(%s) handle_sjoin: got userlist %r for %r', self.name, userlist, channel)
         for userpair in userlist:
             # charybdis sends this in the form "@+UID1, +UID2, UID3, @UID4"
             r = re.search(r'([^\d]*)(.*)', userpair)
@@ -440,30 +440,30 @@ class TS6Protocol(TS6BaseProtocol):
             modeprefix = r.group(1) or ''
             finalprefix = ''
             assert user, 'Failed to get the UID from %r; our regex needs updating?' % userpair
-            log.debug('(%s) handle_sjoin: got modeprefix %r for user %r', self.irc.name, modeprefix, user)
+            log.debug('(%s) handle_sjoin: got modeprefix %r for user %r', self.name, modeprefix, user)
 
             # Don't crash when we get an invalid UID.
-            if user not in self.irc.users:
+            if user not in self.users:
                 log.debug('(%s) handle_sjoin: tried to introduce user %s not in our user list, ignoring...',
-                          self.irc.name, user)
+                          self.name, user)
                 continue
 
             for m in modeprefix:
                 # Iterate over the mapping of prefix chars to prefixes, and
                 # find the characters that match.
-                for char, prefix in self.irc.prefixmodes.items():
+                for char, prefix in self.prefixmodes.items():
                     if m == prefix:
                         finalprefix += char
             namelist.append(user)
-            self.irc.users[user].channels.add(channel)
+            self.users[user].channels.add(channel)
 
             # Only save mode changes if the remote has lower TS than us.
             changedmodes |= {('+%s' % mode, user) for mode in finalprefix}
-            self.irc.channels[channel].users.add(user)
+            self.channels[channel].users.add(user)
 
         # Statekeeping with timestamps
         their_ts = int(args[0])
-        our_ts = self.irc.channels[channel].ts
+        our_ts = self.channels[channel].ts
         self.updateTS(servernumeric, channel, their_ts, changedmodes)
 
         return {'channel': channel, 'users': namelist, 'modes': parsedmodes, 'ts': their_ts,
@@ -476,24 +476,24 @@ class TS6Protocol(TS6BaseProtocol):
         ts = int(args[0])
         if args[0] == '0':
             # /join 0; part the user from all channels
-            oldchans = self.irc.users[numeric].channels.copy()
+            oldchans = self.users[numeric].channels.copy()
             log.debug('(%s) Got /join 0 from %r, channel list is %r',
-                      self.irc.name, numeric, oldchans)
+                      self.name, numeric, oldchans)
             for channel in oldchans:
-                self.irc.channels[channel].users.discard(numeric)
-                self.irc.users[numeric].channels.discard(channel)
+                self.channels[channel].users.discard(numeric)
+                self.users[numeric].channels.discard(channel)
             return {'channels': oldchans, 'text': 'Left all channels.', 'parse_as': 'PART'}
         else:
-            channel = self.irc.toLower(args[1])
+            channel = self.toLower(args[1])
             self.updateTS(numeric, channel, ts)
 
-            self.irc.users[numeric].channels.add(channel)
-            self.irc.channels[channel].users.add(numeric)
+            self.users[numeric].channels.add(channel)
+            self.channels[channel].users.add(numeric)
 
         # We send users and modes here because SJOIN and JOIN both use one hook,
         # for simplicity's sake (with plugins).
         return {'channel': channel, 'users': [numeric], 'modes':
-                self.irc.channels[channel].modes, 'ts': ts}
+                self.channels[channel].modes, 'ts': ts}
 
     def handle_euid(self, numeric, command, args):
         """Handles incoming EUID commands (user introduction)."""
@@ -505,28 +505,28 @@ class TS6Protocol(TS6BaseProtocol):
             realhost = None
 
         log.debug('(%s) handle_euid got args: nick=%s ts=%s uid=%s ident=%s '
-                  'host=%s realname=%s realhost=%s ip=%s', self.irc.name, nick, ts, uid,
+                  'host=%s realname=%s realhost=%s ip=%s', self.name, nick, ts, uid,
                   ident, host, realname, realhost, ip)
         assert ts != 0, "Bad TS 0 for user %s" % uid
 
         if ip == '0':  # IP was invalid; something used for services.
             ip = '0.0.0.0'
 
-        self.irc.users[uid] = IrcUser(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
+        self.users[uid] = IrcUser(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
 
-        parsedmodes = self.irc.parseModes(uid, [modes])
+        parsedmodes = self.parseModes(uid, [modes])
         log.debug('Applying modes %s for %s', parsedmodes, uid)
-        self.irc.applyModes(uid, parsedmodes)
-        self.irc.servers[numeric].users.add(uid)
+        self.applyModes(uid, parsedmodes)
+        self.servers[numeric].users.add(uid)
 
         # Call the OPERED UP hook if +o is being added to the mode list.
         if ('+o', None) in parsedmodes:
             otype = 'Server Administrator' if ('+a', None) in parsedmodes else 'IRC Operator'
-            self.irc.callHooks([uid, 'CLIENT_OPERED', {'text': otype}])
+            self.callHooks([uid, 'CLIENT_OPERED', {'text': otype}])
 
         # Set the accountname if present
         if accountname != "*":
-            self.irc.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': accountname}])
+            self.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': accountname}])
 
         return {'uid': uid, 'ts': ts, 'nick': nick, 'realhost': realhost, 'host': host, 'ident': ident, 'ip': ip}
 
@@ -555,7 +555,7 @@ class TS6Protocol(TS6BaseProtocol):
         servername = args[0].lower()
         sid = args[2]
         sdesc = args[-1]
-        self.irc.servers[sid] = IrcServer(numeric, servername, desc=sdesc)
+        self.servers[sid] = IrcServer(numeric, servername, desc=sdesc)
         return {'name': servername, 'sid': sid, 'text': sdesc}
 
     def handle_server(self, numeric, command, args):
@@ -563,35 +563,35 @@ class TS6Protocol(TS6BaseProtocol):
         Handles 1) incoming legacy (no SID) server introductions,
         2) Sending server data in initial connection.
         """
-        if numeric == self.irc.uplink and not self.irc.servers[numeric].name:
+        if numeric == self.uplink and not self.servers[numeric].name:
             # <- SERVER charybdis.midnight.vpn 1 :charybdis test server
             sname = args[0].lower()
 
-            log.debug('(%s) Found uplink server name as %r', self.irc.name, sname)
-            self.irc.servers[numeric].name = sname
-            self.irc.servers[numeric].desc = args[-1]
+            log.debug('(%s) Found uplink server name as %r', self.name, sname)
+            self.servers[numeric].name = sname
+            self.servers[numeric].desc = args[-1]
 
             # According to the TS6 protocol documentation, we should send SVINFO
             # when we get our uplink's SERVER command.
-            self.irc.send('SVINFO 6 6 0 :%s' % int(time.time()))
+            self.send('SVINFO 6 6 0 :%s' % int(time.time()))
 
             return
 
         # <- :services.int SERVER a.bc 2 :(H) [GL] a
         servername = args[0].lower()
         sdesc = args[-1]
-        self.irc.servers[servername] = IrcServer(numeric, servername, desc=sdesc)
+        self.servers[servername] = IrcServer(numeric, servername, desc=sdesc)
         return {'name': servername, 'sid': None, 'text': sdesc}
 
     def handle_tmode(self, numeric, command, args):
         """Handles incoming TMODE commands (channel mode change)."""
         # <- :42XAAAAAB TMODE 1437450768 #test -c+lkC 3 agte4
         # <- :0UYAAAAAD TMODE 0 #a +h 0UYAAAAAD
-        channel = self.irc.toLower(args[1])
-        oldobj = self.irc.channels[channel].deepcopy()
+        channel = self.toLower(args[1])
+        oldobj = self.channels[channel].deepcopy()
         modes = args[2:]
-        changedmodes = self.irc.parseModes(channel, modes)
-        self.irc.applyModes(channel, changedmodes)
+        changedmodes = self.parseModes(channel, modes)
+        self.applyModes(channel, changedmodes)
         ts = int(args[0])
         return {'target': channel, 'modes': changedmodes, 'ts': ts,
                 'channeldata': oldobj}
@@ -601,42 +601,42 @@ class TS6Protocol(TS6BaseProtocol):
         # <- :70MAAAAAA MODE 70MAAAAAA -i+xc
         target = args[0]
         modestrings = args[1:]
-        changedmodes = self.irc.parseModes(target, modestrings)
-        self.irc.applyModes(target, changedmodes)
+        changedmodes = self.parseModes(target, modestrings)
+        self.applyModes(target, changedmodes)
         # Call the OPERED UP hook if +o is being set.
         if ('+o', None) in changedmodes:
-            otype = 'Server Administrator' if ('a', None) in self.irc.users[target].modes else 'IRC Operator'
-            self.irc.callHooks([target, 'CLIENT_OPERED', {'text': otype}])
+            otype = 'Server Administrator' if ('a', None) in self.users[target].modes else 'IRC Operator'
+            self.callHooks([target, 'CLIENT_OPERED', {'text': otype}])
         return {'target': target, 'modes': changedmodes}
 
     def handle_tb(self, numeric, command, args):
         """Handles incoming topic burst (TB) commands."""
         # <- :42X TB #chat 1467427448 GL!~gl@127.0.0.1 :test
-        channel = self.irc.toLower(args[0])
+        channel = self.toLower(args[0])
         ts = args[1]
         setter = args[2]
         topic = args[-1]
-        self.irc.channels[channel].topic = topic
-        self.irc.channels[channel].topicset = True
+        self.channels[channel].topic = topic
+        self.channels[channel].topicset = True
         return {'channel': channel, 'setter': setter, 'ts': ts, 'text': topic}
 
     def handle_etb(self, numeric, command, args):
         """Handles extended topic burst (ETB)."""
         # <- :00AAAAAAC ETB 0 #test 1470021157 GL :test | abcd
         # Same as TB, with extra TS and extensions arguments.
-        channel = self.irc.toLower(args[1])
+        channel = self.toLower(args[1])
         ts = args[2]
         setter = args[3]
         topic = args[-1]
-        self.irc.channels[channel].topic = topic
-        self.irc.channels[channel].topicset = True
+        self.channels[channel].topic = topic
+        self.channels[channel].topicset = True
         return {'channel': channel, 'setter': setter, 'ts': ts, 'text': topic}
 
     def handle_invite(self, numeric, command, args):
         """Handles incoming INVITEs."""
         # <- :70MAAAAAC INVITE 0ALAAAAAA #blah 12345
         target = args[0]
-        channel = self.irc.toLower(args[1])
+        channel = self.toLower(args[1])
         try:
             ts = args[3]
         except IndexError:
@@ -647,20 +647,20 @@ class TS6Protocol(TS6BaseProtocol):
     def handle_chghost(self, numeric, command, args):
         """Handles incoming CHGHOST commands."""
         target = self._get_UID(args[0])
-        self.irc.users[target].host = newhost = args[1]
+        self.users[target].host = newhost = args[1]
         return {'target': target, 'newhost': newhost}
 
     def handle_bmask(self, numeric, command, args):
         """Handles incoming BMASK commands (ban propagation on burst)."""
         # <- :42X BMASK 1424222769 #dev b :*!test@*.isp.net *!badident@*
         # This is used for propagating bans, not TMODE!
-        channel = self.irc.toLower(args[1])
+        channel = self.toLower(args[1])
         mode = args[2]
         ts = int(args[0])
         modes = []
         for ban in args[-1].split():
             modes.append(('+%s' % mode, ban))
-        self.irc.applyModes(channel, modes)
+        self.applyModes(channel, modes)
         return {'target': channel, 'modes': modes, 'ts': ts}
 
     def handle_472(self, numeric, command, args):
@@ -681,7 +681,7 @@ class TS6Protocol(TS6BaseProtocol):
             log.warning('(%s) User %r attempted to set channel mode %r, but the '
                         'extension providing it isn\'t loaded! To prevent possible'
                         ' desyncs, try adding the line "loadmodule "extensions/%s.so";" to '
-                        'your IRCd configuration.', self.irc.name, setter, badmode,
+                        'your IRCd configuration.', self.name, setter, badmode,
                         charlist[badmode])
 
     def handle_su(self, numeric, command, args):
@@ -696,7 +696,7 @@ class TS6Protocol(TS6BaseProtocol):
             account = ''  # No account name means a logout
 
         uid = args[0]
-        self.irc.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': account}])
+        self.callHooks([uid, 'CLIENT_SERVICES_LOGIN', {'text': account}])
 
     def handle_rsfnc(self, numeric, command, args):
         """

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -79,7 +79,7 @@ class TS6SIDGenerator():
         """
         Returns the next unused TS6 SID for the server.
         """
-        while ''.join(self.output) in self.irc.servers:
+        while ''.join(self.output) in self.servers:
             # Increment until the SID we have doesn't already exist.
             self.increment()
         sid = ''.join(self.output)
@@ -110,7 +110,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def _send_with_prefix(self, source, msg, **kwargs):
         """Sends a TS6-style raw command from a source numeric to the self.irc connection given."""
-        self.irc.send(':%s %s' % (source, msg), **kwargs)
+        self.send(':%s %s' % (source, msg), **kwargs)
 
     def _expandPUID(self, uid):
         """
@@ -134,11 +134,11 @@ class TS6BaseProtocol(IRCS2SProtocol):
     def kick(self, numeric, channel, target, reason=None):
         """Sends kicks from a PyLink client/server."""
 
-        if (not self.irc.isInternalClient(numeric)) and \
-                (not self.irc.isInternalServer(numeric)):
+        if (not self.isInternalClient(numeric)) and \
+                (not self.isInternalServer(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
-        channel = self.irc.toLower(channel)
+        channel = self.toLower(channel)
         if not reason:
             reason = 'No reason given'
 
@@ -155,8 +155,8 @@ class TS6BaseProtocol(IRCS2SProtocol):
     def kill(self, numeric, target, reason):
         """Sends a kill from a PyLink client/server."""
 
-        if (not self.irc.isInternalClient(numeric)) and \
-                (not self.irc.isInternalServer(numeric)):
+        if (not self.isInternalClient(numeric)) and \
+                (not self.isInternalServer(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
         # From TS6 docs:
@@ -167,41 +167,41 @@ class TS6BaseProtocol(IRCS2SProtocol):
         # the kill followed by a space and a parenthesized reason. To avoid overflow,
         # it is recommended not to add anything to the path.
 
-        assert target in self.irc.users, "Unknown target %r for kill()!" % target
+        assert target in self.users, "Unknown target %r for kill()!" % target
 
-        if numeric in self.irc.users:
+        if numeric in self.users:
             # Killer was an user. Follow examples of setting the path to be "killer.host!killer.nick".
-            userobj = self.irc.users[numeric]
+            userobj = self.users[numeric]
             killpath = '%s!%s' % (userobj.host, userobj.nick)
-        elif numeric in self.irc.servers:
+        elif numeric in self.servers:
             # Sender was a server; killpath is just its name.
-            killpath = self.irc.servers[numeric].name
+            killpath = self.servers[numeric].name
         else:
             # Invalid sender?! This shouldn't happen, but make the killpath our server name anyways.
             log.warning('(%s) Invalid sender %s for kill(); using our server name instead.',
-                        self.irc.name, numeric)
-            killpath = self.irc.servers[self.irc.sid].name
+                        self.name, numeric)
+            killpath = self.servers[self.sid].name
 
         self._send_with_prefix(numeric, 'KILL %s :%s (%s)' % (target, killpath, reason))
         self.removeClient(target)
 
     def nick(self, numeric, newnick):
         """Changes the nick of a PyLink client."""
-        if not self.irc.isInternalClient(numeric):
+        if not self.isInternalClient(numeric):
             raise LookupError('No such PyLink client exists.')
 
         self._send_with_prefix(numeric, 'NICK %s %s' % (newnick, int(time.time())))
 
-        self.irc.users[numeric].nick = newnick
+        self.users[numeric].nick = newnick
 
         # Update the NICK TS.
-        self.irc.users[numeric].ts = int(time.time())
+        self.users[numeric].ts = int(time.time())
 
     def part(self, client, channel, reason=None):
         """Sends a part from a PyLink client."""
-        channel = self.irc.toLower(channel)
-        if not self.irc.isInternalClient(client):
-            log.error('(%s) Error trying to part %r from %r (no such client exists)', self.irc.name, client, channel)
+        channel = self.toLower(channel)
+        if not self.isInternalClient(client):
+            log.error('(%s) Error trying to part %r from %r (no such client exists)', self.name, client, channel)
             raise LookupError('No such PyLink client exists.')
         msg = "PART %s" % channel
         if reason:
@@ -211,7 +211,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def quit(self, numeric, reason):
         """Quits a PyLink client."""
-        if self.irc.isInternalClient(numeric):
+        if self.isInternalClient(numeric):
             self._send_with_prefix(numeric, "QUIT :%s" % reason)
             self.removeClient(numeric)
         else:
@@ -219,7 +219,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def message(self, numeric, target, text):
         """Sends a PRIVMSG from a PyLink client."""
-        if not self.irc.isInternalClient(numeric):
+        if not self.isInternalClient(numeric):
             raise LookupError('No such PyLink client exists.')
 
         # Mangle message targets for IRCds that require it.
@@ -229,8 +229,8 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def notice(self, numeric, target, text):
         """Sends a NOTICE from a PyLink client or server."""
-        if (not self.irc.isInternalClient(numeric)) and \
-                (not self.irc.isInternalServer(numeric)):
+        if (not self.isInternalClient(numeric)) and \
+                (not self.isInternalServer(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
         # Mangle message targets for IRCds that require it.
@@ -240,11 +240,11 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def topic(self, numeric, target, text):
         """Sends a TOPIC change from a PyLink client."""
-        if not self.irc.isInternalClient(numeric):
+        if not self.isInternalClient(numeric):
             raise LookupError('No such PyLink client exists.')
         self._send_with_prefix(numeric, 'TOPIC %s :%s' % (target, text))
-        self.irc.channels[target].topic = text
-        self.irc.channels[target].topicset = True
+        self.channels[target].topic = text
+        self.channels[target].topicset = True
 
     def spawnServer(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
         """
@@ -257,23 +257,23 @@ class TS6BaseProtocol(IRCS2SProtocol):
         option will be ignored if given.
         """
         # -> :0AL SID test.server 1 0XY :some silly pseudoserver
-        uplink = uplink or self.irc.sid
+        uplink = uplink or self.sid
         name = name.lower()
-        desc = desc or self.irc.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']
+        desc = desc or self.serverdata.get('serverdesc') or conf.conf['bot']['serverdesc']
         if sid is None:  # No sid given; generate one!
             sid = self.sidgen.next_sid()
         assert len(sid) == 3, "Incorrect SID length"
-        if sid in self.irc.servers:
+        if sid in self.servers:
             raise ValueError('A server with SID %r already exists!' % sid)
-        for server in self.irc.servers.values():
+        for server in self.servers.values():
             if name == server.name:
                 raise ValueError('A server named %r already exists!' % name)
-        if not self.irc.isInternalServer(uplink):
+        if not self.isInternalServer(uplink):
             raise ValueError('Server %r is not a PyLink server!' % uplink)
         if not utils.isServerName(name):
             raise ValueError('Invalid server name %r' % name)
         self._send_with_prefix(uplink, 'SID %s 1 %s :%s' % (name, sid, desc))
-        self.irc.servers[sid] = IrcServer(uplink, name, internal=True, desc=desc)
+        self.servers[sid] = IrcServer(uplink, name, internal=True, desc=desc)
         return sid
 
     def squit(self, source, target, text='No reason given'):
@@ -290,13 +290,13 @@ class TS6BaseProtocol(IRCS2SProtocol):
             self._send_with_prefix(source, 'AWAY :%s' % text)
         else:
             self._send_with_prefix(source, 'AWAY')
-        self.irc.users[source].away = text
+        self.users[source].away = text
 
     ### HANDLERS
     def handle_kick(self, source, command, args):
         """Handles incoming KICKs."""
         # :70MAAAAAA KICK #test 70MAAAAAA :some reason
-        channel = self.irc.toLower(args[0])
+        channel = self.toLower(args[0])
         kicked = self._get_UID(args[1])
 
         try:
@@ -304,18 +304,18 @@ class TS6BaseProtocol(IRCS2SProtocol):
         except IndexError:
             reason = ''
 
-        log.debug('(%s) Removing kick target %s from %s', self.irc.name, kicked, channel)
+        log.debug('(%s) Removing kick target %s from %s', self.name, kicked, channel)
         self.handle_part(kicked, 'KICK', [channel, reason])
         return {'channel': channel, 'target': kicked, 'text': reason}
 
     def handle_nick(self, numeric, command, args):
         """Handles incoming NICK changes."""
         # <- :70MAAAAAA NICK GL-devel 1434744242
-        oldnick = self.irc.users[numeric].nick
-        newnick = self.irc.users[numeric].nick = args[0]
+        oldnick = self.users[numeric].nick
+        newnick = self.users[numeric].nick = args[0]
 
         # Update the nick TS.
-        self.irc.users[numeric].ts = ts = int(args[1])
+        self.users[numeric].ts = ts = int(args[1])
 
         return {'newnick': newnick, 'oldnick': oldnick, 'ts': ts}
 
@@ -330,12 +330,12 @@ class TS6BaseProtocol(IRCS2SProtocol):
         # -> :0AL000001 NICK Derp_ 1433728673
         # <- :70M SAVE 0AL000001 1433728673
         user = args[0]
-        oldnick = self.irc.users[user].nick
-        self.irc.users[user].nick = user
+        oldnick = self.users[user].nick
+        self.users[user].nick = user
 
         # TS6 SAVE sets nick TS to 100. This is hardcoded in InspIRCd and
         # charybdis.
-        self.irc.users[user].ts = 100
+        self.users[user].ts = 100
 
         return {'target': user, 'ts': 100, 'oldnick': oldnick}
 
@@ -343,33 +343,33 @@ class TS6BaseProtocol(IRCS2SProtocol):
         """Handles incoming TOPIC changes from clients. For topic bursts,
         TB (TS6/charybdis) and FTOPIC (InspIRCd) are used instead."""
         # <- :70MAAAAAA TOPIC #test :test
-        channel = self.irc.toLower(args[0])
+        channel = self.toLower(args[0])
         topic = args[1]
 
-        oldtopic = self.irc.channels[channel].topic
-        self.irc.channels[channel].topic = topic
-        self.irc.channels[channel].topicset = True
+        oldtopic = self.channels[channel].topic
+        self.channels[channel].topic = topic
+        self.channels[channel].topicset = True
 
         return {'channel': channel, 'setter': numeric, 'text': topic,
                 'oldtopic': oldtopic}
 
     def handle_part(self, source, command, args):
         """Handles incoming PART commands."""
-        channels = self.irc.toLower(args[0]).split(',')
+        channels = self.toLower(args[0]).split(',')
         for channel in channels:
             # We should only get PART commands for channels that exist, right??
-            self.irc.channels[channel].removeuser(source)
+            self.channels[channel].removeuser(source)
             try:
-                self.irc.users[source].channels.discard(channel)
+                self.users[source].channels.discard(channel)
             except KeyError:
-                log.debug("(%s) handle_part: KeyError trying to remove %r from %r's channel list?", self.irc.name, channel, source)
+                log.debug("(%s) handle_part: KeyError trying to remove %r from %r's channel list?", self.name, channel, source)
             try:
                 reason = args[1]
             except IndexError:
                 reason = ''
             # Clear empty non-permanent channels.
-            if not (self.irc.channels[channel].users or ((self.irc.cmodes.get('permanent'), None) in self.irc.channels[channel].modes)):
-                del self.irc.channels[channel]
+            if not (self.channels[channel].users or ((self.cmodes.get('permanent'), None) in self.channels[channel].modes)):
+                del self.channels[channel]
         return {'channels': channels, 'text': reason}
 
     def handle_svsnick(self, source, command, args):

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -134,11 +134,11 @@ class TS6BaseProtocol(IRCS2SProtocol):
     def kick(self, numeric, channel, target, reason=None):
         """Sends kicks from a PyLink client/server."""
 
-        if (not self.isInternalClient(numeric)) and \
-                (not self.isInternalServer(numeric)):
+        if (not self.is_internal_client(numeric)) and \
+                (not self.is_internal_server(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
-        channel = self.toLower(channel)
+        channel = self.to_lower(channel)
         if not reason:
             reason = 'No reason given'
 
@@ -155,8 +155,8 @@ class TS6BaseProtocol(IRCS2SProtocol):
     def kill(self, numeric, target, reason):
         """Sends a kill from a PyLink client/server."""
 
-        if (not self.isInternalClient(numeric)) and \
-                (not self.isInternalServer(numeric)):
+        if (not self.is_internal_client(numeric)) and \
+                (not self.is_internal_server(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
         # From TS6 docs:
@@ -187,7 +187,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def nick(self, numeric, newnick):
         """Changes the nick of a PyLink client."""
-        if not self.isInternalClient(numeric):
+        if not self.is_internal_client(numeric):
             raise LookupError('No such PyLink client exists.')
 
         self._send_with_prefix(numeric, 'NICK %s %s' % (newnick, int(time.time())))
@@ -199,8 +199,8 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def part(self, client, channel, reason=None):
         """Sends a part from a PyLink client."""
-        channel = self.toLower(channel)
-        if not self.isInternalClient(client):
+        channel = self.to_lower(channel)
+        if not self.is_internal_client(client):
             log.error('(%s) Error trying to part %r from %r (no such client exists)', self.name, client, channel)
             raise LookupError('No such PyLink client exists.')
         msg = "PART %s" % channel
@@ -211,7 +211,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def quit(self, numeric, reason):
         """Quits a PyLink client."""
-        if self.isInternalClient(numeric):
+        if self.is_internal_client(numeric):
             self._send_with_prefix(numeric, "QUIT :%s" % reason)
             self._remove_client(numeric)
         else:
@@ -219,7 +219,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def message(self, numeric, target, text):
         """Sends a PRIVMSG from a PyLink client."""
-        if not self.isInternalClient(numeric):
+        if not self.is_internal_client(numeric):
             raise LookupError('No such PyLink client exists.')
 
         # Mangle message targets for IRCds that require it.
@@ -229,8 +229,8 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def notice(self, numeric, target, text):
         """Sends a NOTICE from a PyLink client or server."""
-        if (not self.isInternalClient(numeric)) and \
-                (not self.isInternalServer(numeric)):
+        if (not self.is_internal_client(numeric)) and \
+                (not self.is_internal_server(numeric)):
             raise LookupError('No such PyLink client/server exists.')
 
         # Mangle message targets for IRCds that require it.
@@ -240,7 +240,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
     def topic(self, numeric, target, text):
         """Sends a TOPIC change from a PyLink client."""
-        if not self.isInternalClient(numeric):
+        if not self.is_internal_client(numeric):
             raise LookupError('No such PyLink client exists.')
         self._send_with_prefix(numeric, 'TOPIC %s :%s' % (target, text))
         self.channels[target].topic = text
@@ -268,7 +268,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
         for server in self.servers.values():
             if name == server.name:
                 raise ValueError('A server named %r already exists!' % name)
-        if not self.isInternalServer(uplink):
+        if not self.is_internal_server(uplink):
             raise ValueError('Server %r is not a PyLink server!' % uplink)
         if not utils.isServerName(name):
             raise ValueError('Invalid server name %r' % name)
@@ -296,7 +296,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
     def handle_kick(self, source, command, args):
         """Handles incoming KICKs."""
         # :70MAAAAAA KICK #test 70MAAAAAA :some reason
-        channel = self.toLower(args[0])
+        channel = self.to_lower(args[0])
         kicked = self._get_UID(args[1])
 
         try:
@@ -343,7 +343,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
         """Handles incoming TOPIC changes from clients. For topic bursts,
         TB (TS6/charybdis) and FTOPIC (InspIRCd) are used instead."""
         # <- :70MAAAAAA TOPIC #test :test
-        channel = self.toLower(args[0])
+        channel = self.to_lower(args[0])
         topic = args[1]
 
         oldtopic = self.channels[channel].topic

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -353,25 +353,6 @@ class TS6BaseProtocol(IRCS2SProtocol):
         return {'channel': channel, 'setter': numeric, 'text': topic,
                 'oldtopic': oldtopic}
 
-    def handle_part(self, source, command, args):
-        """Handles incoming PART commands."""
-        channels = self.toLower(args[0]).split(',')
-        for channel in channels:
-            # We should only get PART commands for channels that exist, right??
-            self.channels[channel].removeuser(source)
-            try:
-                self.users[source].channels.discard(channel)
-            except KeyError:
-                log.debug("(%s) handle_part: KeyError trying to remove %r from %r's channel list?", self.name, channel, source)
-            try:
-                reason = args[1]
-            except IndexError:
-                reason = ''
-            # Clear empty non-permanent channels.
-            if not (self.channels[channel].users or ((self.cmodes.get('permanent'), None) in self.channels[channel].modes)):
-                del self.channels[channel]
-        return {'channels': channels, 'text': reason}
-
     def handle_svsnick(self, source, command, args):
         """Handles SVSNICK (forced nickname change attempts)."""
         # InspIRCd:

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -298,7 +298,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
         """Handles incoming KICKs."""
         # :70MAAAAAA KICK #test 70MAAAAAA :some reason
         channel = self.irc.toLower(args[0])
-        kicked = self._getUid(args[1])
+        kicked = self._get_UID(args[1])
 
         try:
             reason = args[2]
@@ -381,4 +381,4 @@ class TS6BaseProtocol(IRCS2SProtocol):
 
         # UnrealIRCd:
         # <- :services.midnight.vpn SVSNICK GL Guest87795 1468303726
-        return {'target': self._getUid(args[0]), 'newnick': args[1]}
+        return {'target': self._get_UID(args[0]), 'newnick': args[1]}

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -99,15 +99,14 @@ class TS6UIDGenerator(utils.IncrementalUIDGenerator):
          super().__init__(sid)
 
 class TS6BaseProtocol(IRCS2SProtocol):
-
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # Dictionary of UID generators (one for each server).
         self.uidgen = structures.KeyedDefaultdict(TS6UIDGenerator)
 
         # SID generator for TS6.
-        self.sidgen = TS6SIDGenerator(irc)
+        self.sidgen = TS6SIDGenerator(self)
 
     def _send_with_prefix(self, source, msg, **kwargs):
         """Sends a TS6-style raw command from a source numeric to the self.irc connection given."""

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -246,7 +246,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
         self.channels[target].topic = text
         self.channels[target].topicset = True
 
-    def spawnServer(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
+    def spawn_server(self, name, sid=None, uplink=None, desc=None, endburst_delay=0):
         """
         Spawns a server off a PyLink server. desc (server description)
         defaults to the one in the config. uplink defaults to the main PyLink

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -79,7 +79,7 @@ class TS6SIDGenerator():
         """
         Returns the next unused TS6 SID for the server.
         """
-        while ''.join(self.output) in self.servers:
+        while ''.join(self.output) in self.irc.servers:
             # Increment until the SID we have doesn't already exist.
             self.increment()
         sid = ''.join(self.output)

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -273,7 +273,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
         if not utils.isServerName(name):
             raise ValueError('Invalid server name %r' % name)
         self._send_with_prefix(uplink, 'SID %s 1 %s :%s' % (name, sid, desc))
-        self.servers[sid] = IrcServer(uplink, name, internal=True, desc=desc)
+        self.servers[sid] = Server(uplink, name, internal=True, desc=desc)
         return sid
 
     def squit(self, source, target, text='No reason given'):

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -183,7 +183,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
             killpath = self.servers[self.sid].name
 
         self._send_with_prefix(numeric, 'KILL %s :%s (%s)' % (target, killpath, reason))
-        self.removeClient(target)
+        self._remove_client(target)
 
     def nick(self, numeric, newnick):
         """Changes the nick of a PyLink client."""
@@ -213,7 +213,7 @@ class TS6BaseProtocol(IRCS2SProtocol):
         """Quits a PyLink client."""
         if self.isInternalClient(numeric):
             self._send_with_prefix(numeric, "QUIT :%s" % reason)
-            self.removeClient(numeric)
+            self._remove_client(numeric)
         else:
             raise LookupError("No such PyLink client exists.")
 

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -511,7 +511,7 @@ class UnrealProtocol(TS6BaseProtocol):
         """Handles the SQUIT command."""
         # <- SQUIT services.int :Read error
         # Convert the server name to a SID...
-        args[0] = self._getSid(args[0])
+        args[0] = self._get_SID(args[0])
         # Then, use the SQUIT handler in TS6BaseProtocol as usual.
         return super().handle_squit(numeric, 'SQUIT', args)
 

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -21,8 +21,8 @@ SJOIN_PREFIXES = {'q': '*', 'a': '~', 'o': '@', 'h': '%', 'v': '+', 'b': '&', 'e
 S2S_BUFSIZE = 427
 
 class UnrealProtocol(TS6BaseProtocol):
-    def __init__(self, irc):
-        super().__init__(irc)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.protocol_caps |= {'slash-in-nicks', 'underscore-in-hosts'}
         # Set our case mapping (rfc1459 maps "\" and "|" together, for example)
         self.casemapping = 'ascii'
@@ -335,7 +335,7 @@ class UnrealProtocol(TS6BaseProtocol):
 
     ### HANDLERS
 
-    def connect(self):
+    def post_connect(self):
         """Initializes a connection to a server."""
         ts = self.irc.start_ts
         self.irc.prefixmodes = {'q': '~', 'a': '&', 'o': '@', 'h': '%', 'v': '+'}

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -274,7 +274,7 @@ class UnrealProtocol(TS6BaseProtocol):
         self.channels[target].topic = text
         self.channels[target].topicset = True
 
-    def updateClient(self, target, field, text):
+    def update_client(self, target, field, text):
         """Updates the ident, host, or realname of any connected client."""
         field = field.upper()
 

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -266,7 +266,7 @@ class UnrealProtocol(TS6BaseProtocol):
             joinedmodes = self.join_modes(modes)
             self._send_with_prefix(target, 'UMODE2 %s' % joinedmodes)
 
-    def topicBurst(self, numeric, target, text):
+    def topic_burst(self, numeric, target, text):
         """Sends a TOPIC change from a PyLink server."""
         if not self.is_internal_server(numeric):
             raise LookupError('No such PyLink server exists.')

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -485,7 +485,7 @@ class UnrealProtocol(TS6BaseProtocol):
             if protover < self.min_proto_ver:
                 raise ProtocolError("Protocol version too old! (needs at least %s "
                                     "(Unreal 4.x), got %s)" % (self.min_proto_ver, protover))
-            self.servers[numeric] = IrcServer(None, sname, desc=sdesc)
+            self.servers[numeric] = Server(None, sname, desc=sdesc)
 
             # Set irc.connected to True, meaning that protocol negotiation passed.
             log.debug('(%s) self.connected set!', self.name)
@@ -495,7 +495,7 @@ class UnrealProtocol(TS6BaseProtocol):
             # <- :services.int SERVER a.bc 2 :(H) [GL] a
             servername = args[0].lower()
             sdesc = args[-1]
-            self.servers[servername] = IrcServer(numeric, servername, desc=sdesc)
+            self.servers[servername] = Server(numeric, servername, desc=sdesc)
             return {'name': servername, 'sid': None, 'text': sdesc}
 
     def handle_sid(self, numeric, command, args):
@@ -504,7 +504,7 @@ class UnrealProtocol(TS6BaseProtocol):
         sname = args[0].lower()
         sid = args[2]
         sdesc = args[-1]
-        self.servers[sid] = IrcServer(numeric, sname, desc=sdesc)
+        self.servers[sid] = Server(numeric, sname, desc=sdesc)
         return {'name': sname, 'sid': sid, 'text': sdesc}
 
     def handle_squit(self, numeric, command, args):

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -56,7 +56,7 @@ class UnrealProtocol(TS6BaseProtocol):
         return uid
 
     ### OUTGOING COMMAND FUNCTIONS
-    def spawnClient(self, nick, ident='null', host='null', realhost=None, modes=set(),
+    def spawn_client(self, nick, ident='null', host='null', realhost=None, modes=set(),
             server=None, ip='0.0.0.0', realname=None, ts=None, opertype='IRC Operator',
             manipulatable=False):
         """

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -624,7 +624,7 @@ class UnrealProtocol(TS6BaseProtocol):
                     # <- :002 SJOIN 1486361658 #idlerpg :@
                     continue
 
-                user = self._getUid(user)  # Normalize nicks to UIDs for Unreal 3.2 links
+                user = self._get_UID(user)  # Normalize nicks to UIDs for Unreal 3.2 links
                 # Unreal uses slightly different prefixes in SJOIN. +q is * instead of ~,
                 # and +a is ~ instead of &.
                 modeprefix = (r.group(1) or '').replace("~", "&").replace("*", "~")
@@ -769,7 +769,7 @@ class UnrealProtocol(TS6BaseProtocol):
     def handle_svsmode(self, numeric, command, args):
         """Handles SVSMODE, used by services for setting user modes on others."""
         # <- :source SVSMODE target +usermodes
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         modes = args[1:]
 
         parsedmodes = self.irc.parseModes(target, modes)
@@ -817,7 +817,7 @@ class UnrealProtocol(TS6BaseProtocol):
         # <- :NickServ SVS2MODE 001SALZ01 +d GL
         # <- :NickServ SVS2MODE 001SALZ01 +r
 
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         parsedmodes = self.irc.parseModes(target, args[1:])
 
         if ('+r', None) in parsedmodes:
@@ -911,14 +911,14 @@ class UnrealProtocol(TS6BaseProtocol):
     def handle_chgident(self, numeric, command, args):
         """Handles CHGIDENT, used for denoting ident changes."""
         # <- :GL CHGIDENT GL test
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         self.irc.users[target].ident = newident = args[1]
         return {'target': target, 'newident': newident}
 
     def handle_chghost(self, numeric, command, args):
         """Handles CHGHOST, used for denoting hostname changes."""
         # <- :GL CHGHOST GL some.host
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         self.irc.users[target].host = newhost = args[1]
 
         # When SETHOST or CHGHOST is used, modes +xt are implicitly set on the
@@ -930,14 +930,14 @@ class UnrealProtocol(TS6BaseProtocol):
     def handle_chgname(self, numeric, command, args):
         """Handles CHGNAME, used for denoting real name/gecos changes."""
         # <- :GL CHGNAME GL :afdsafasf
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         self.irc.users[target].realname = newgecos = args[1]
         return {'target': target, 'newgecos': newgecos}
 
     def handle_invite(self, numeric, command, args):
         """Handles incoming INVITEs."""
         # <- :GL INVITE PyLink-devel :#a
-        target = self._getUid(args[0])
+        target = self._get_UID(args[0])
         channel = self.irc.toLower(args[1])
         # We don't actually need to process this; it's just something plugins/hooks can use
         return {'target': target, 'channel': channel}
@@ -947,7 +947,7 @@ class UnrealProtocol(TS6BaseProtocol):
         # <- :GL| KILL GLolol :hidden-1C620195!GL| (test)
         # Use ts6_common's handle_kill, but coerse UIDs to nicks first.
 
-        new_args = [self._getUid(args[0])]
+        new_args = [self._get_UID(args[0])]
         new_args.extend(args[1:])
 
         return super().handle_kill(numeric, command, new_args)

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -934,14 +934,6 @@ class UnrealProtocol(TS6BaseProtocol):
         self.users[target].realname = newgecos = args[1]
         return {'target': target, 'newgecos': newgecos}
 
-    def handle_invite(self, numeric, command, args):
-        """Handles incoming INVITEs."""
-        # <- :GL INVITE PyLink-devel :#a
-        target = self._get_UID(args[0])
-        channel = self.toLower(args[1])
-        # We don't actually need to process this; it's just something plugins/hooks can use
-        return {'target': target, 'channel': channel}
-
     def handle_kill(self, numeric, command, args):
         """Handles incoming KILLs."""
         # <- :GL| KILL GLolol :hidden-1C620195!GL| (test)

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -732,7 +732,7 @@ class UnrealProtocol(TS6BaseProtocol):
             # User mode change: pass those on to handle_umode2()
             self.handle_umode2(numeric, 'MODE', args[1:])
 
-    def checkCloakChange(self, uid, parsedmodes):
+    def _check_cloak_change(self, uid, parsedmodes):
         """
         Checks whether +x/-x was set in the mode query, and changes the
         hostname of the user given to or from their cloaked host if True.
@@ -776,7 +776,7 @@ class UnrealProtocol(TS6BaseProtocol):
         self.applyModes(target, parsedmodes)
 
         # If +x/-x is being set, update cloaked host info.
-        self.checkCloakChange(target, parsedmodes)
+        self._check_cloak_change(target, parsedmodes)
 
         return {'target': target, 'modes': parsedmodes}
 
@@ -865,7 +865,7 @@ class UnrealProtocol(TS6BaseProtocol):
             # If +o being set, call the CLIENT_OPERED internal hook.
             self.callHooks([numeric, 'CLIENT_OPERED', {'text': 'IRC Operator'}])
 
-        self.checkCloakChange(numeric, parsedmodes)
+        self._check_cloak_change(numeric, parsedmodes)
 
         return {'target': numeric, 'modes': parsedmodes}
 

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -82,7 +82,7 @@ class UnrealProtocol(TS6BaseProtocol):
         modes |= {('+x', None), ('+t', None)}
 
         raw_modes = self.join_modes(modes)
-        u = self.users[uid] = IrcUser(nick, ts, uid, server, ident=ident, host=host, realname=realname,
+        u = self.users[uid] = User(nick, ts, uid, server, ident=ident, host=host, realname=realname,
             realhost=realhost, ip=ip, manipulatable=manipulatable, opertype=opertype)
         self.apply_modes(uid, modes)
         self.servers[server].users.add(uid)
@@ -418,7 +418,7 @@ class UnrealProtocol(TS6BaseProtocol):
 
         realname = args[-1]
 
-        self.users[uid] = IrcUser(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
+        self.users[uid] = User(nick, ts, uid, numeric, ident, host, realname, realhost, ip)
         self.servers[numeric].users.add(uid)
 
         # Handle user modes

--- a/pylink
+++ b/pylink
@@ -85,7 +85,7 @@ if __name__ == '__main__':
         else:
             # Fetch the correct protocol module
             proto = utils.getProtocolModule(protoname)
-            world.networkobjects[network] = irc = classes.Irc(network, proto, conf.conf)
+            world.networkobjects[network] = proto.Class(network)
 
     world.started.set()
     log.info("Loaded plugins: %s", ', '.join(sorted(world.plugins.keys())))

--- a/pylink
+++ b/pylink
@@ -83,9 +83,13 @@ if __name__ == '__main__':
         except (KeyError, TypeError):
             log.error("(%s) Configuration error: No protocol module specified, aborting.", network)
         else:
-            # Fetch the correct protocol module
+            # Fetch the correct protocol module.
             proto = utils.getProtocolModule(protoname)
-            world.networkobjects[network] = proto.Class(network)
+
+            # Create and connect the network.
+            world.networkobjects[network] = irc = proto.Class(network)
+            log.debug('Connecting to network %r', network)
+            irc.connect()
 
     world.started.set()
     log.info("Loaded plugins: %s", ', '.join(sorted(world.plugins.keys())))

--- a/utils.py
+++ b/utils.py
@@ -627,6 +627,6 @@ class CamelCaseToSnakeCase():
         if normalized_attr == attr:
             # __getattr__ only fires if normal attribute fetching fails, so we can assume that
             # the attribute was tried already and failed.
-            raise AttributeError('%s object has no attribute of normalized name %r' % (__class__.__name__, attr))
+            raise AttributeError('%s object has no attribute of normalized name %r' % (self.__class__.__name__, attr))
 
         return getattr(self, normalized_attr)

--- a/utils.py
+++ b/utils.py
@@ -129,25 +129,6 @@ def isHostmask(text):
     # Band-aid patch here to prevent bad bans set by Janus forwarding people into invalid channels.
     return hostmaskRe.match(text) and '#' not in text
 
-def parseModes(irc, target, args):
-    """Parses a modestring list into a list of (mode, argument) tuples.
-    ['+mitl-o', '3', 'person'] => [('+m', None), ('+i', None), ('+t', None), ('+l', '3'), ('-o', 'person')]
-
-    This method is deprecated. Use irc.parseModes() instead.
-    """
-    log.warning("(%s) utils.parseModes is deprecated. Use irc.parseModes() instead!", irc.name)
-    return irc.parseModes(target, args)
-
-def applyModes(irc, target, changedmodes):
-    """Takes a list of parsed IRC modes, and applies them on the given target.
-
-    The target can be either a channel or a user; this is handled automatically.
-
-    This method is deprecated. Use irc.applyModes() instead.
-    """
-    log.warning("(%s) utils.applyModes is deprecated. Use irc.applyModes() instead!", irc.name)
-    return irc.applyModes(target, changedmodes)
-
 def expandpath(path):
     """
     Returns a path expanded with environment variables and home folders (~) expanded, in that order."""

--- a/utils.py
+++ b/utils.py
@@ -606,3 +606,27 @@ class DeprecatedAttributesObject():
                         self.deprecated_attributes.get(attr)))
 
         return object.__getattribute__(self, attr)
+
+class CamelCaseToSnakeCase():
+    """
+    Class which automatically converts missing attributes from camel case to snake case.
+    """
+
+    def __getattr__(self, attr):
+        """
+        Attribute fetching fallback function which normalizes camel case attributes to snake case.
+        """
+        assert isinstance(attr, str), "Requested attribute %r is not a string!" % attr
+
+        normalized_attr = ''  # Start off with the first letter, which is ignored when processing
+        for char in attr:
+            if char in string.ascii_uppercase:
+                char = '_' + char.lower()
+            normalized_attr += char
+
+        if normalized_attr == attr:
+            # __getattr__ only fires if normal attribute fetching fails, so we can assume that
+            # the attribute was tried already and failed.
+            raise AttributeError('%s object has no attribute of normalized name %r' % (__class__.__name__, attr))
+
+        return getattr(self, normalized_attr)

--- a/utils.py
+++ b/utils.py
@@ -624,9 +624,12 @@ class CamelCaseToSnakeCase():
                 char = '_' + char.lower()
             normalized_attr += char
 
+        classname = self.__class__.__name__
         if normalized_attr == attr:
             # __getattr__ only fires if normal attribute fetching fails, so we can assume that
             # the attribute was tried already and failed.
-            raise AttributeError('%s object has no attribute with normalized name %r' % (self.__class__.__name__, attr))
+            raise AttributeError('%s object has no attribute with normalized name %r' % (classname, attr))
 
-        return getattr(self, normalized_attr)
+        target = getattr(self, normalized_attr)
+        log.warning('%s.%s is deprecated, considering migrating to %s.%s!', classname, attr, classname, normalized_attr)
+        return target

--- a/utils.py
+++ b/utils.py
@@ -595,6 +595,8 @@ class DeprecatedAttributesObject():
     """
     Object implementing deprecated attributes and warnings on access.
     """
+    def __init__(self):
+        self.deprecated_attributes = {}
 
     def __getattribute__(self, attr):
         # Note: "self.deprecated_attributes" calls this too, so the != check is

--- a/utils.py
+++ b/utils.py
@@ -231,7 +231,7 @@ class ServiceBot():
         # which is handled by coreplugin.
         if irc is None:
             for irc in world.networkobjects.values():
-                irc.callHooks([None, 'PYLINK_NEW_SERVICE', {'name': self.name}])
+                irc.call_hooks([None, 'PYLINK_NEW_SERVICE', {'name': self.name}])
         else:
             raise NotImplementedError("Network specific plugins not supported yet.")
 
@@ -282,7 +282,7 @@ class ServiceBot():
                 else:
                     irc.proto.join(u, chan)
 
-                irc.callHooks([irc.sid, 'PYLINK_SERVICE_JOIN', {'channel': chan, 'users': [u]}])
+                irc.call_hooks([irc.sid, 'PYLINK_SERVICE_JOIN', {'channel': chan, 'users': [u]}])
             else:
                 log.warning('(%s) Ignoring invalid autojoin channel %r.', irc.name, chan)
 
@@ -324,10 +324,10 @@ class ServiceBot():
             if cmd and show_unknown_cmds and not cmd.startswith('\x01'):
                 # Ignore empty commands and invalid command errors from CTCPs.
                 self.reply(irc, 'Error: Unknown command %r.' % cmd)
-            log.info('(%s/%s) Received unknown command %r from %s', irc.name, self.name, cmd, irc.getHostmask(source))
+            log.info('(%s/%s) Received unknown command %r from %s', irc.name, self.name, cmd, irc.get_hostmask(source))
             return
 
-        log.info('(%s/%s) Calling command %r for %s', irc.name, self.name, cmd, irc.getHostmask(source))
+        log.info('(%s/%s) Calling command %r for %s', irc.name, self.name, cmd, irc.get_hostmask(source))
         for func in self.commands[cmd]:
             try:
                 func(irc, source, cmd_args)

--- a/utils.py
+++ b/utils.py
@@ -582,7 +582,8 @@ class DeprecatedAttributesObject():
     def __getattribute__(self, attr):
         # Note: "self.deprecated_attributes" calls this too, so the != check is
         # needed to prevent a recursive loop!
-        if attr != 'deprecated_attributes' and attr in self.deprecated_attributes:
+        # Also ignore reserved names beginning with "__".
+        if attr != 'deprecated_attributes' and not attr.startswith('__') and attr in self.deprecated_attributes:
             log.warning('Attribute %s.%s is deprecated: %s' % (self.__class__.__name__, attr,
                         self.deprecated_attributes.get(attr)))
 

--- a/utils.py
+++ b/utils.py
@@ -627,6 +627,6 @@ class CamelCaseToSnakeCase():
         if normalized_attr == attr:
             # __getattr__ only fires if normal attribute fetching fails, so we can assume that
             # the attribute was tried already and failed.
-            raise AttributeError('%s object has no attribute of normalized name %r' % (self.__class__.__name__, attr))
+            raise AttributeError('%s object has no attribute with normalized name %r' % (self.__class__.__name__, attr))
 
         return getattr(self, normalized_attr)


### PR DESCRIPTION
This is a giant cleanup merge that encompasses issues #454 and #371, along with other related work as well:

- [x] Replace camel case variables in `Irc` with snake case
   - [x] Leave a migration stub with a deprecation warning
   - [x] Do this in plugins/coremods too
- [x] Remove the `Irc` prefix from classes as needed (e.g. `IrcChannel` is now just `Channel`)
    - [x] Make other parts of PyLink follow this change
- [x] Split `Irc` up into multiple classes
    - As of 2a978c4, this involves 3 classes inheriting in this order: `IRCNetwork` → `PyLinkNetworkCoreWithUtils` → `PyLinkNetworkCore`
    - The goal so far is to keep `PyLinkNetworkCore` consistent for all protocols, while `PyLinkNetworkCoreWithUtils` and its subclasses can be replaced with more relevant code on other protocols (things like mode handling, `get_hostmask`, etc. are especially relevant here)
- [x] Merge the IRC controller and protocol stacks together - realistically, both will need to be override-able for future extensions to non-IRC protocols, so having this
   - This new setup involves IRC Protocol base classes such as `ircs2s_common.IRCCommonProtocol` directly inheriting from `IRCNetwork`
   - [x] Check for namespace conflicts and rename things as needed
      - [x] `proto.connect()` → `proto.post_connect()` - **this is an API breaking change!**
      - [x] `proto._send()` → `proto._send_with_prefix()` - ok since this is an internal function
   - [x] Figure out what to do with outgoing command function names: names like `irc.mode()` and `irc.numeric()` are a bit ambiguous IMO now that the protocol distinction is gone... - keep as-is but rename functions to snake case
   - [ ] Update protocol spec docs #478
- [x] Finish off #454
- [x] Make sure things like autoconnect, queue processing, etc. work - we could really use some unit tests at this point...
- [ ] Check and update plugins as needed
   - [x] Make sure REHASH works (especially regarding network reconnections)
   - [x] Check the `networks` plugin (i.e. `disconnect`)
   - [x] Do some basic Relay tests
   - [ ] Check contrib plugins
- [x] Consider if we're better off breaking some more things and making this v2.0 already :)