### PR TITLE
opercmds: add chghost, chgident, chgname commands

### DIFF
--- a/docs/permissions-reference.md
+++ b/docs/permissions-reference.md
@@ -77,6 +77,7 @@ Remote versions of the `manage`, `list`, `sync`, and `clear` commands also exist
 - `opercmds.kill` - Allows access to the `kill` command.
 - `opercmds.mode` - Allows access to the `mode` command.
 - `opercmds.topic` - Allows access to the `topic` command.
+- `opercmds.chghost` - Allows access to the `chghost`, `chgident`, and `chgname` commands.
 
 ## Relay
 - `relay.claim` - Allows access to the `claim` command.

--- a/docs/permissions-reference.md
+++ b/docs/permissions-reference.md
@@ -77,7 +77,9 @@ Remote versions of the `manage`, `list`, `sync`, and `clear` commands also exist
 - `opercmds.kill` - Allows access to the `kill` command.
 - `opercmds.mode` - Allows access to the `mode` command.
 - `opercmds.topic` - Allows access to the `topic` command.
-- `opercmds.chghost` - Allows access to the `chghost`, `chgident`, and `chgname` commands.
+- `opercmds.chghost` - Allows access to the `chghost` command.
+- `opercmds.chgident` - Allows access to the `chgident` command.
+- `opercmds.chgname` - Allows access to the `chgname` command.
 
 ## Relay
 - `relay.claim` - Allows access to the `claim` command.

--- a/plugins/opercmds.py
+++ b/plugins/opercmds.py
@@ -221,25 +221,26 @@ def chgident(irc, source, args):
     
 @utils.add_cmd
 def chgname(irc, source, args):
-    """<user> <new GECOS>
+    """<user> <new name>
 
     Admin only. Changes the GECOS (realname) of the target user."""
-    chgfield(irc, source, args, 'GECOS')
+    chgfield(irc, source, args, 'name', 'GECOS')
 
-def chgfield(irc, source, args, field):
-    permissions.checkPermissions(irc, source, ['opercmds.chghost'])
+def chgfield(irc, source, args, human_field, internal_field=None):
+    permissions.checkPermissions(irc, source, ['opercmds.chg' + human_field])
     try:
         target = args[0]
         new = args[1]
     except IndexError:
-        irc.error("Not enough arguments. Needs 2: target, new %s." % field)
+        irc.error("Not enough arguments. Needs 2: target, new %s." % human_field)
         return
     
     # Find the user
     targetu = irc.nick_to_uid(target)
     if targetu not in irc.users:
-        irc.error("No such nick '%s'." % target)
+        irc.error("No such nick %r." % target)
         return
         
-    irc.update_client(targetu, field.upper(), new)
+    internal_field = internal_field or human_field.upper()
+    irc.update_client(targetu, internal_field, new)
     irc.reply("Done.")

--- a/plugins/opercmds.py
+++ b/plugins/opercmds.py
@@ -204,3 +204,42 @@ def topic(irc, source, args):
     irc.call_hooks([irc.pseudoclient.uid, 'CHANCMDS_TOPIC',
                    {'channel': channel, 'text': topic, 'setter': source,
                     'parse_as': 'TOPIC'}])
+
+@utils.add_cmd
+def chghost(irc, source, args):
+    """<user> <new host>
+
+    Admin only. Changes the visible host of the target user."""
+    chgfield(irc, source, args, 'host')
+
+@utils.add_cmd
+def chgident(irc, source, args):
+    """<user> <new ident>
+
+    Admin only. Changes the ident of the target user."""
+    chgfield(irc, source, args, 'ident')
+    
+@utils.add_cmd
+def chgname(irc, source, args):
+    """<user> <new GECOS>
+
+    Admin only. Changes the GECOS (realname) of the target user."""
+    chgfield(irc, source, args, 'GECOS')
+
+def chgfield(irc, source, args, field):
+    permissions.checkPermissions(irc, source, ['opercmds.chghost'])
+    try:
+        target = args[0]
+        new = args[1]
+    except IndexError:
+        irc.error("Not enough arguments. Needs 2: target, new %s." % field)
+        return
+    
+    # Find the user
+    targetu = irc.nick_to_uid(target)
+    if targetu not in irc.users:
+        irc.error("No such nick '%s'." % target)
+        return
+        
+    irc.update_client(targetu, field.upper(), new)
+    irc.reply("Done.")


### PR DESCRIPTION
#481 

I made all 3 of these use the `opercmds.chghost` priv, but it would be easy to separate them if desired.