### PR TITLE
.gitignore: ignore .idea/ due to PyCharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 env/
 build/
 __pycache__/
+.idea/
 *.py[cod]
 *.bak
 *~


### PR DESCRIPTION
* PyCharm keeps state inside of .idea/ which may contain sensitive information